### PR TITLE
Add generation support for const properties

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
@@ -9,8 +9,10 @@ import net.theevilreaper.dartpoet.function.DartFunctionSpec
 import net.theevilreaper.dartpoet.import.DartImport
 import net.theevilreaper.dartpoet.import.LibraryImport
 import net.theevilreaper.dartpoet.import.PartImport
+import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.util.*
+import net.theevilreaper.dartpoet.util.ALLOWED_CONST_MODIFIERS
 import net.theevilreaper.dartpoet.util.DART_FILE_ENDING
-import net.theevilreaper.dartpoet.util.isDartConventionFileName
 import net.theevilreaper.dartpoet.util.toImmutableList
 import java.io.IOException
 import java.io.OutputStreamWriter
@@ -26,6 +28,12 @@ class DartFile internal constructor(
     internal val annotations: List<AnnotationSpec> = builder.annotations.toImmutableList()
     internal val types: List<Any> = builder.specTypes.toImmutableList()
     internal val extensions: List<ExtensionSpec> = builder.extensionStack
+    internal val constants: Set<DartPropertySpec> = builder.constants.onEach {
+        // Only check modifiers when the size is not zero
+        if (it.modifiers.isNotEmpty()) {
+            hasAllowedModifiers(it.modifiers, ALLOWED_CONST_MODIFIERS, "file const")
+        }
+    }.toImmutableSet()
 
     internal val imports: List<DartImport> = if (builder.imports.isEmpty()) {
         emptyList()

--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
@@ -6,6 +6,7 @@ import net.theevilreaper.dartpoet.clazz.DartClassSpec
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.import.Import
+import net.theevilreaper.dartpoet.property.DartPropertySpec
 import net.theevilreaper.dartpoet.util.DEFAULT_INDENT
 import java.lang.IllegalArgumentException
 
@@ -18,6 +19,23 @@ class DartFileBuilder(
     internal val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal val extensionStack: MutableList<ExtensionSpec> = mutableListOf()
     internal var indent = DEFAULT_INDENT
+    internal val constants: MutableSet<DartPropertySpec> = mutableSetOf()
+
+    /**
+     * Add a constant [DartPropertySpec] to the file.
+     * @param constant the property to add
+     */
+    fun constant(constant: DartPropertySpec) = apply {
+        this.constants += constant
+    }
+
+    /**
+     * Add an array of constant [DartPropertySpec] to the file.
+     * @param constants the array to add
+     */
+    fun constants(vararg constants: DartPropertySpec) = apply {
+        this.constants += constants
+    }
 
     fun import(import: Import) = apply {
         this.imports += import
@@ -62,8 +80,8 @@ class DartFileBuilder(
         this.specTypes += dartFileSpec
     }
 
-    fun type(dartFileSpec: () -> DartClassSpec) = apply {
-        this.specTypes += dartFileSpec()
+    fun type(vararg classSpecs: DartClassSpec) = apply {
+        this.specTypes += classSpecs
     }
 
     fun type(dartFileSpec: DartClassBuilder) = apply {
@@ -74,14 +92,18 @@ class DartFileBuilder(
         this.annotations += annotations
     }
 
-    fun annotation(annotation: () -> AnnotationSpec) = apply {
-        this.annotations += annotation()
+    fun annotation(vararg annotations: AnnotationSpec) = apply {
+        this.annotations += annotations
     }
 
     fun annotation(annotation: AnnotationSpec) = apply {
         this.annotations += annotation
     }
 
+    /**
+     * Creates a new reference from the [DartFile] class.
+     * @return the created instance
+     */
     fun build(): DartFile {
         return DartFile(this)
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/DartClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/DartClassBuilder.kt
@@ -28,6 +28,7 @@ class DartClassBuilder internal constructor(
     internal val propertyStack: MutableList<DartPropertySpec> = mutableListOf()
     internal val functionStack: MutableList<DartFunctionSpec> = mutableListOf()
     internal val enumPropertyStack: MutableList<EnumPropertySpec> = mutableListOf()
+    internal val constantStack: MutableSet<DartPropertySpec> = mutableSetOf()
 
     internal var superClass: String? = null
     internal var inheritKeyWord: InheritKeyword? = null
@@ -46,6 +47,22 @@ class DartClassBuilder internal constructor(
     fun withImplements(className: String) = apply {
         setClassName(className)
         this.inheritKeyWord = InheritKeyword.IMPLEMENTS
+    }
+
+    /**
+     * Add a constant [DartPropertySpec] to the file.
+     * @param constant the property to add
+     */
+    fun constant(constant: DartPropertySpec) = apply {
+        this.constantStack += constant
+    }
+
+    /**
+     * Add an array of constant [DartPropertySpec] to the file.
+     * @param constants the array to add
+     */
+    fun constants(vararg constants: DartPropertySpec) = apply {
+        this.constantStack += constants
     }
 
     fun enumProperty(enumPropertySpec: EnumPropertySpec) = apply {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/DartClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/DartClassSpec.kt
@@ -5,6 +5,7 @@ import net.theevilreaper.dartpoet.DartModifier.*
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.ClassWriter
+import net.theevilreaper.dartpoet.util.*
 import net.theevilreaper.dartpoet.util.toImmutableList
 import net.theevilreaper.dartpoet.util.toImmutableSet
 
@@ -31,9 +32,13 @@ class DartClassSpec internal constructor(
     internal val constructors = builder.constructorStack.toImmutableSet()
     internal val typeDefStack = builder.functionStack.filter { it.isTypeDef }.toImmutableSet()
     internal val enumPropertyStack = builder.enumPropertyStack.toImmutableList()
+    internal val constantStack = builder.constantStack.onEach {
+        hasAllowedModifiers(it.modifiers, ALLOWED_CLASS_CONST_MODIFIERS, "class constants")
+        it.modifiers = it.modifiers.sorted().toSet()
+    }.toImmutableSet()
 
     internal val hasNoContent: Boolean
-        get() = functions.isEmpty() && properties.isEmpty() && constructors.isEmpty()
+        get() = functions.isEmpty() && properties.isEmpty() && constructors.isEmpty() && constantStack.isEmpty()
 
     init {
         if (name != null) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
@@ -6,6 +6,7 @@ import net.theevilreaper.dartpoet.function.DartFunctionSpec
 import net.theevilreaper.dartpoet.function.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.import.Import
 import net.theevilreaper.dartpoet.parameter.DartParameterSpec
+import net.theevilreaper.dartpoet.property.DartPropertySpec
 import net.theevilreaper.dartpoet.util.CURLY_CLOSE
 import net.theevilreaper.dartpoet.util.CURLY_OPEN
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
@@ -176,5 +177,23 @@ internal fun <T: Import> List<T>.writeImports(
         }
 
         writer.emit(NEW_LINE)
+    }
+}
+
+fun Set<DartPropertySpec>.emitProperties(
+    codeWriter: CodeWriter,
+    forceNewLines: Boolean = false,
+    emitBlock: (DartPropertySpec) -> Unit = { it.write(codeWriter) }
+) = with(codeWriter) {
+    if (isNotEmpty()) {
+        val emitNewLines = size > 1 || forceNewLines
+
+        forEachIndexed { index, property ->
+            if (index > 0) {
+                emit(if (emitNewLines) NEW_LINE else EMPTY_STRING)
+            }
+            emitBlock(property)
+        }
+        emit(NEW_LINE)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -73,6 +73,14 @@ class ClassWriter {
             codeWriter.emit(NEW_LINE)
         }
 
+        spec.constantStack.emit(codeWriter) {
+            it.write(codeWriter)
+        }
+
+        if (spec.constantStack.isNotEmpty()) {
+            codeWriter.emit(NEW_LINE)
+        }
+
         spec.properties.emit(codeWriter) {
             it.write(codeWriter)
         }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -3,7 +3,7 @@ package net.theevilreaper.dartpoet.code.writer
 import net.theevilreaper.dartpoet.DartModifier.*
 import net.theevilreaper.dartpoet.clazz.ClassType
 import net.theevilreaper.dartpoet.clazz.DartClassSpec
-import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.*
 import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.code.emitConstructors
 import net.theevilreaper.dartpoet.code.emitFunctions
@@ -73,17 +73,13 @@ class ClassWriter {
             codeWriter.emit(NEW_LINE)
         }
 
-        spec.constantStack.emit(codeWriter) {
-            it.write(codeWriter)
-        }
+        spec.constantStack.emitProperties(codeWriter)
 
         if (spec.constantStack.isNotEmpty()) {
             codeWriter.emit(NEW_LINE)
         }
 
-        spec.properties.emit(codeWriter) {
-            it.write(codeWriter)
-        }
+        spec.properties.emitProperties(codeWriter)
 
         if (spec.properties.isNotEmpty()) {
             codeWriter.emit(NEW_LINE)
@@ -173,24 +169,6 @@ class ClassWriter {
                     codeWriter.emit(",$NEW_LINE")
                 }
             }
-        }
-    }
-
-    private fun Set<DartPropertySpec>.emit(
-        codeWriter: CodeWriter,
-        forceNewLines: Boolean = false,
-        emitBlock: (DartPropertySpec) -> Unit = { it.write(codeWriter) }
-    ) = with(codeWriter) {
-        if (isNotEmpty()) {
-            val emitNewLines = size > 1 || forceNewLines
-
-            forEachIndexed { index, property ->
-                if (index > 0) {
-                    emit(if (emitNewLines) NEW_LINE else EMPTY_STRING)
-                }
-                emitBlock(property)
-            }
-            emit(NEW_LINE)
         }
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
@@ -4,6 +4,7 @@ import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.clazz.DartClassSpec
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.emitExtensions
+import net.theevilreaper.dartpoet.code.emitProperties
 import net.theevilreaper.dartpoet.code.writeImports
 import net.theevilreaper.dartpoet.util.NEW_LINE
 
@@ -34,6 +35,14 @@ class DartFileWriter {
         }
 
         if (dartFile.partImports.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+        }
+
+        dartFile.constants.emitProperties(writer) {
+            it.write(writer)
+        }
+
+        if (dartFile.constants.isNotEmpty()) {
             writer.emit(NEW_LINE)
         }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
@@ -15,12 +15,19 @@ class PropertyWriter {
             it.write(writer, inline = false)
         }
 
-        for (modifier in property.modifiers) {
+        property.modifiers.forEachIndexed { index, modifier ->
+            if (index > 0) {
+                writer.emit(SPACE)
+            }
             writer.emit(modifier.identifier)
-            writer.emit(SPACE)
         }
 
-        writer.emit(property.type)
+        if (!property.isConst) {
+            if (property.modifiers.isNotEmpty()) {
+                writer.emit(SPACE)
+            }
+            writer.emit(property.type)
+        }
 
         if (property.nullable) {
             writer.emit("? ")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/DartPropertyBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/DartPropertyBuilder.kt
@@ -15,7 +15,7 @@ class DartPropertyBuilder internal constructor(
     var type: String,
 ) {
     internal var nullable = false
-    internal val modifiers: MutableList<DartModifier> = mutableListOf()
+    internal val modifiers: MutableSet<DartModifier> = mutableSetOf()
     internal val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal var initBlock: CodeBlock.Builder = CodeBlock.builder()
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/DartPropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/DartPropertySpec.kt
@@ -6,7 +6,8 @@ import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.writer.PropertyWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.util.toImmutableSet
-import net.theevilreaper.dartpoet.util.ALLOWED_PARAMETER_MODIFIERS
+import net.theevilreaper.dartpoet.util.ALLOWED_PROPERTY_MODIFIERS
+import net.theevilreaper.dartpoet.util.hasAllowedModifiers
 
 /**
  * The property spec class contains all variables which are comes from the [DartPropertyBuilder].
@@ -17,23 +18,16 @@ import net.theevilreaper.dartpoet.util.ALLOWED_PARAMETER_MODIFIERS
 class DartPropertySpec(
     builder: DartPropertyBuilder
 ) {
-
     internal var name = builder.name
     internal var type = builder.type
     internal var annotations: Set<AnnotationSpec> = builder.annotations.toImmutableSet()
     internal var nullable = builder.nullable
     internal var initBlock = builder.initBlock
     internal var isPrivate = builder.modifiers.contains(DartModifier.PRIVATE)
-
     internal var modifiers: Set<DartModifier> = builder.modifiers
         .also {
-            LinkedHashSet(it).apply {
-                removeAll(ALLOWED_PARAMETER_MODIFIERS)
-                if (!isEmpty()) {
-                    throw IllegalArgumentException("Modifiers $this are not allowed on Kotlin parameters. Allowed modifiers: $ALLOWED_PARAMETER_MODIFIERS")
-                }
-            }
-        }.filter { it != DartModifier.PRIVATE }.toImmutableSet()
+            hasAllowedModifiers(it, ALLOWED_PROPERTY_MODIFIERS, "property")
+        }.filter { it != DartModifier.PRIVATE && it != DartModifier.PUBLIC }.toImmutableSet()
 
     init {
         check(name.trim().isNotEmpty()) { "The name of a parameter can't be empty" }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/DartPropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/DartPropertySpec.kt
@@ -24,6 +24,7 @@ class DartPropertySpec(
     internal var nullable = builder.nullable
     internal var initBlock = builder.initBlock
     internal var isPrivate = builder.modifiers.contains(DartModifier.PRIVATE)
+    internal val isConst = builder.type == "CONST"
     internal var modifiers: Set<DartModifier> = builder.modifiers
         .also {
             hasAllowedModifiers(it, ALLOWED_PROPERTY_MODIFIERS, "property")
@@ -66,5 +67,8 @@ class DartPropertySpec(
         ): DartPropertyBuilder {
             return DartPropertyBuilder(name, type).modifiers { listOf(*modifiers) }
         }
+
+        @JvmStatic
+        fun constBuilder(name: String) = DartPropertyBuilder(name, "CONST").modifier(DartModifier.CONST)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -21,7 +21,6 @@ internal const val IMPORT = "import"
 internal const val ANNOTATION_CHAR = "@"
 
 internal const val DART_FILE_ENDING = ".dart"
-internal const val CONSTRUCTOR = "CONSTRUCTOR"
 
 //Brackets
 internal const val CURLY_OPEN = '{'
@@ -31,9 +30,10 @@ internal const val ROUND_OPEN = "("
 internal const val ROUND_CLOSE = ")"
 
 internal val ALLOWED_PARAMETER_MODIFIERS = setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.LATE, DartModifier.FINAL, DartModifier.CONST, DartModifier.STATIC)
-
 internal val ALLOWED_FUNCTION_MODIFIERS = setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC, DartModifier.TYPEDEF)
-
+internal val ALLOWED_PROPERTY_MODIFIERS = setOf(DartModifier.PRIVATE, DartModifier.FINAL, DartModifier.LATE, DartModifier.STATIC, DartModifier.CONST)
+internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.STATIC, DartModifier.CONST)
+internal val ALLOWED_CONST_MODIFIERS = setOf(DartModifier.CONST)
 private val namePattern: Regex = Regex("[a-z]+|([a-z]+)_+([a-z]+)")
 private val lowerCamelCase: Regex = Regex("[a-z]+[A-Z0-9]*[a-z0-9]*[A-Za-z0-9]*")
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -313,4 +313,33 @@ class DartFileTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `test class write with constant values`() {
+        val name = "environment"
+        val classFile = DartFile.builder(name)
+            .import(DartImport("dart:html"))
+            .constants(
+                DartPropertySpec.constBuilder("typeLive").initWith("1").build(),
+                DartPropertySpec.constBuilder("typeTest").initWith("10").build(),
+                DartPropertySpec.constBuilder("typeDev").initWith("100").build(),
+            )
+            .type(
+                DartClassSpec.builder(name.replaceFirstChar { it.uppercase() })
+                    .annotation(AnnotationSpec.builder("freezed").build())
+            )
+            .build()
+        assertThat(classFile.toString()).isEqualTo(
+            """
+            import 'dart:html';
+            
+            const typeLive = 1;
+            const typeTest = 10;
+            const typeDev = 100;
+            
+            @freezed
+            class Environment {}
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
## Proposed changes

Dart allows the definition of properties that are constant. These can be outside or inside a class. The pull request add the generation support for those properties

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...