### PR TITLE
Update names of some spec und builder classes

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
@@ -5,13 +5,13 @@ import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.DartFileWriter
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.util.*
 import net.theevilreaper.dartpoet.util.ALLOWED_CONST_MODIFIERS
 import net.theevilreaper.dartpoet.directive.DartDirective
 import net.theevilreaper.dartpoet.directive.LibraryDirective
 import net.theevilreaper.dartpoet.directive.PartDirective
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.util.DART_FILE_ENDING
 import net.theevilreaper.dartpoet.util.isDartConventionFileName
 import net.theevilreaper.dartpoet.util.toImmutableList
@@ -31,7 +31,7 @@ class DartFile internal constructor(
     internal val extensions: List<ExtensionSpec> = builder.extensionStack
     internal val docs = builder.docs
 
-    internal val constants: Set<DartPropertySpec> = builder.constants.onEach {
+    internal val constants: Set<PropertySpec> = builder.constants.onEach {
         // Only check modifiers when the size is not zero
         if (it.modifiers.isNotEmpty()) {
             hasAllowedModifiers(it.modifiers, ALLOWED_CONST_MODIFIERS, "file const")
@@ -77,7 +77,7 @@ class DartFile internal constructor(
 
     private fun emitInternal(o: Any, c: CodeWriter) {
         when (o::class) {
-            DartFunctionSpec::class -> {
+            FunctionSpec::class -> {
                 callEmit(o, c)
             }
         }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
@@ -1,12 +1,12 @@
 package net.theevilreaper.dartpoet
 
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
-import net.theevilreaper.dartpoet.clazz.DartClassBuilder
-import net.theevilreaper.dartpoet.clazz.DartClassSpec
+import net.theevilreaper.dartpoet.clazz.ClassBuilder
+import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.directive.Directive
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.util.DEFAULT_INDENT
 import java.lang.IllegalArgumentException
 
@@ -14,22 +14,22 @@ class DartFileBuilder(
     val name: String
 ) {
     internal val docs: MutableList<CodeBlock> = mutableListOf()
-    internal val specTypes: MutableList<DartClassSpec> = mutableListOf()
+    internal val specTypes: MutableList<ClassSpec> = mutableListOf()
     internal val directives: MutableList<Directive> = mutableListOf()
     internal val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal val extensionStack: MutableList<ExtensionSpec> = mutableListOf()
     internal var indent = DEFAULT_INDENT
-    internal val constants: MutableSet<DartPropertySpec> = mutableSetOf()
+    internal val constants: MutableSet<PropertySpec> = mutableSetOf()
 
     /**
-     * Add a constant [DartPropertySpec] to the file.
+     * Add a constant [PropertySpec] to the file.
      * @param constant the property to add
      */
-    fun constant(constant: DartPropertySpec) = apply {
+    fun constant(constant: PropertySpec) = apply {
         this.constants += constant
     }
 
-    fun constants(vararg constants: DartPropertySpec) = apply {
+    fun constants(vararg constants: PropertySpec) = apply {
         this.constants += constants
     }
 
@@ -50,6 +50,7 @@ class DartFileBuilder(
     }
 
     fun indent(indent: String) = apply {
+        //TODO: Only accept spaces
         if (indent.trim().isEmpty()) {
             throw IllegalArgumentException("The indent can't be empty")
         }
@@ -72,15 +73,15 @@ class DartFileBuilder(
         this.extensionStack += extensions
     }
 
-    fun type(dartFileSpec: DartClassSpec) = apply {
+    fun type(dartFileSpec: ClassSpec) = apply {
         this.specTypes += dartFileSpec
     }
 
-    fun type(vararg classSpecs: DartClassSpec) = apply {
+    fun type(vararg classSpecs: ClassSpec) = apply {
         this.specTypes += classSpecs
     }
 
-    fun type(dartFileSpec: DartClassBuilder) = apply {
+    fun type(dartFileSpec: ClassBuilder) = apply {
         this.specTypes += dartFileSpec.build()
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -4,18 +4,18 @@ import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.InheritKeyword
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.enum.EnumPropertySpec
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.meta.SpecData
 import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.function.constructor.ConstructorSpec
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 
 //TODO: Add check to prevent illegal modifiers on some class combinations
-class DartClassBuilder internal constructor(
+class ClassBuilder internal constructor(
     internal val name: String?,
     internal val classType: ClassType,
     vararg modifiers: DartModifier
-) : SpecMethods<DartClassBuilder> {
+) : SpecMethods<ClassBuilder> {
     internal val classMetaData: SpecData = SpecData(*modifiers)
     internal val isAnonymousClass get() = name == null && classType == ClassType.CLASS
     internal val isEnumClass get() = classType == ClassType.ENUM
@@ -23,10 +23,10 @@ class DartClassBuilder internal constructor(
     internal val isAbstract get() = classType == ClassType.ABSTRACT
     internal val isLibrary get() = classType == ClassType.CLASS
     internal val constructorStack: MutableList<ConstructorSpec> = mutableListOf()
-    internal val propertyStack: MutableList<DartPropertySpec> = mutableListOf()
-    internal val functionStack: MutableList<DartFunctionSpec> = mutableListOf()
+    internal val propertyStack: MutableList<PropertySpec> = mutableListOf()
+    internal val functionStack: MutableList<FunctionSpec> = mutableListOf()
     internal val enumPropertyStack: MutableList<EnumPropertySpec> = mutableListOf()
-    internal val constantStack: MutableSet<DartPropertySpec> = mutableSetOf()
+    internal val constantStack: MutableSet<PropertySpec> = mutableSetOf()
     internal var superClass: String? = null
     internal var inheritKeyWord: InheritKeyword? = null
     internal var endWithNewLine = false
@@ -48,18 +48,18 @@ class DartClassBuilder internal constructor(
     }
 
     /**
-     * Add a constant [DartPropertySpec] to the file.
+     * Add a constant [PropertySpec] to the file.
      * @param constant the property to add
      */
-    fun constant(constant: DartPropertySpec) = apply {
+    fun constant(constant: PropertySpec) = apply {
         this.constantStack += constant
     }
 
     /**
-     * Add an array of constant [DartPropertySpec] to the file.
+     * Add an array of constant [PropertySpec] to the file.
      * @param constants the array to add
      */
-    fun constants(vararg constants: DartPropertySpec) = apply {
+    fun constants(vararg constants: PropertySpec) = apply {
         this.constantStack += constants
     }
 
@@ -97,23 +97,23 @@ class DartClassBuilder internal constructor(
         this.endWithNewLine = endWithNewLine
     }
 
-    fun property(dartPropertySpec: DartPropertySpec) = apply {
-        this.propertyStack += dartPropertySpec
+    fun property(propertySpec: PropertySpec) = apply {
+        this.propertyStack += propertySpec
     }
 
-    fun property(dartPropertySpec: () -> DartPropertySpec) = apply {
-        this.propertyStack += dartPropertySpec()
+    fun property(propertySpec: () -> PropertySpec) = apply {
+        this.propertyStack += propertySpec()
     }
 
-    fun properties(vararg properties: DartPropertySpec) = apply {
+    fun properties(vararg properties: PropertySpec) = apply {
         this.propertyStack += properties
     }
 
-    fun function(function: DartFunctionSpec) = apply {
+    fun function(function: FunctionSpec) = apply {
         this.functionStack += function
     }
 
-    fun function(function: () -> DartFunctionSpec) = apply {
+    fun function(function: () -> FunctionSpec) = apply {
         this.functionStack += function()
     }
 
@@ -150,10 +150,10 @@ class DartClassBuilder internal constructor(
     }
 
     /**
-     * Creates a new instance from the [DartClassSpec].
+     * Creates a new instance from the [ClassSpec].
      * @return the created instance
      */
-    fun build(): DartClassSpec {
-        return DartClassSpec(this)
+    fun build(): ClassSpec {
+        return ClassSpec(this)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -10,14 +10,14 @@ import net.theevilreaper.dartpoet.util.toImmutableList
 import net.theevilreaper.dartpoet.util.toImmutableSet
 
 /**
- * A [DartClassBuilder] describes the actual content of the class.
+ * A [ClassBuilder] describes the actual content of the class.
  * The content includes functions, typedefs, const values etc.
  * Partly some things are also only allowed to be set on certain classes.
  * @since 1.0.0
  * @author theEvilReaper
  */
-class DartClassSpec internal constructor(
-    builder: DartClassBuilder
+class ClassSpec internal constructor(
+    builder: ClassBuilder
 ) {
     internal val name = builder.name
     internal val classType = builder.classType
@@ -76,50 +76,50 @@ class DartClassSpec internal constructor(
     override fun toString() = buildCodeString { write(this) }
 
     /**
-     * The class contains methods to create a new [DartClassBuilder] instance for a specific class.
+     * The class contains methods to create a new [ClassBuilder] instance for a specific class.
      */
     companion object {
 
         /**
-         * Create a new [DartClassBuilder] instance for a normal dart class.
+         * Create a new [ClassBuilder] instance for a normal dart class.
          * @return the created instance
          */
         @JvmStatic
-        fun builder(name: String) = DartClassBuilder(name, ClassType.CLASS, DartModifier.CLASS)
+        fun builder(name: String) = ClassBuilder(name, ClassType.CLASS, DartModifier.CLASS)
 
         /**
-         * Create a new [DartClassBuilder] instance for an anonymous dart class.
+         * Create a new [ClassBuilder] instance for an anonymous dart class.
          * @return the created instance
          */
         @JvmStatic
-        fun anonymousClassBuilder() = DartClassBuilder(null, ClassType.CLASS)
+        fun anonymousClassBuilder() = ClassBuilder(null, ClassType.CLASS)
 
         /**
-         * Create a new [DartClassBuilder] instance for an enum dart class.
+         * Create a new [ClassBuilder] instance for an enum dart class.
          * @return the created instance
          */
         @JvmStatic
-        fun enumClass(name: String) = DartClassBuilder(name, ClassType.ENUM)
+        fun enumClass(name: String) = ClassBuilder(name, ClassType.ENUM)
 
         /**
-         * Create a new [DartClassBuilder] instance for a mixin dart class.
+         * Create a new [ClassBuilder] instance for a mixin dart class.
          * @return the created instance
          */
         @JvmStatic
-        fun mixinClass(name: String) = DartClassBuilder(name, ClassType.MIXIN)
+        fun mixinClass(name: String) = ClassBuilder(name, ClassType.MIXIN)
 
         /**
-         * Create a new [DartClassBuilder] instance for an abstract dart class.
+         * Create a new [ClassBuilder] instance for an abstract dart class.
          * @return the created instance
          */
         @JvmStatic
-        fun abstractClass(name: String) = DartClassBuilder(name, ClassType.ABSTRACT)
+        fun abstractClass(name: String) = ClassBuilder(name, ClassType.ABSTRACT)
 
         /**
-         * Creates a new [DartClassBuilder] instance for a library class.
+         * Creates a new [ClassBuilder] instance for a library class.
          * @return the created instance
          */
         @JvmStatic
-        fun libraryClass(name: String) = DartClassBuilder(name, ClassType.LIBRARY)
+        fun libraryClass(name: String) = ClassBuilder(name, ClassType.LIBRARY)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
@@ -2,11 +2,11 @@ package net.theevilreaper.dartpoet.code
 
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.directive.Directive
 import net.theevilreaper.dartpoet.parameter.DartParameterSpec
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.util.CURLY_CLOSE
 import net.theevilreaper.dartpoet.util.CURLY_OPEN
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
@@ -40,9 +40,9 @@ internal val String.isPlaceholder
 fun String.nextPotentialPlaceholderPosition(startIndex: Int) =
     indexOfAny(NO_ARG_PLACEHOLDERS, startIndex)
 
-internal fun Set<DartFunctionSpec>.emitFunctions(
+internal fun Set<FunctionSpec>.emitFunctions(
     codeWriter: CodeWriter,
-    emitBlock: (DartFunctionSpec) -> Unit = { it.write(codeWriter) }
+    emitBlock: (FunctionSpec) -> Unit = { it.write(codeWriter) }
 ) = with(codeWriter) {
     if (isNotEmpty()) {
         val newLines = size > 1
@@ -180,10 +180,10 @@ internal fun <T: Directive> List<T>.writeImports(
     }
 }
 
-fun Set<DartPropertySpec>.emitProperties(
+fun Set<PropertySpec>.emitProperties(
     codeWriter: CodeWriter,
     forceNewLines: Boolean = false,
-    emitBlock: (DartPropertySpec) -> Unit = { it.write(codeWriter) }
+    emitBlock: (PropertySpec) -> Unit = { it.write(codeWriter) }
 ) = with(codeWriter) {
     if (isNotEmpty()) {
         val emitNewLines = size > 1 || forceNewLines

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -2,7 +2,7 @@ package net.theevilreaper.dartpoet.code.writer
 
 import net.theevilreaper.dartpoet.DartModifier.*
 import net.theevilreaper.dartpoet.clazz.ClassType
-import net.theevilreaper.dartpoet.clazz.DartClassSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.*
 import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.code.emitConstructors
@@ -22,7 +22,7 @@ import net.theevilreaper.dartpoet.util.SEMICOLON
 class ClassWriter {
 
     //TODO: Improve new lines after each generated code part block
-    fun write(spec: DartClassSpec, codeWriter: CodeWriter) {
+    fun write(spec: ClassSpec, codeWriter: CodeWriter) {
         if (spec.isAnonymous) {
             writeAnonymousClass(spec, codeWriter)
             return
@@ -107,7 +107,7 @@ class ClassWriter {
         }
     }
 
-    private fun writeAnonymousClass(spec: DartClassSpec, writer: CodeWriter) {
+    private fun writeAnonymousClass(spec: ClassSpec, writer: CodeWriter) {
         spec.typeDefStack.emitFunctions(writer) {
             it.write(writer)
         }
@@ -123,11 +123,11 @@ class ClassWriter {
     }
 
     /**
-     * The method contains the logic to write the dart class declaration for a [DartClassSpec].
-     * @param spec the [DartClassSpec] which contains all data for a class
+     * The method contains the logic to write the dart class declaration for a [ClassSpec].
+     * @param spec the [ClassSpec] which contains all data for a class
      * @param writer the [CodeWriter] to write the class declaration
      */
-    private fun writeClassHeader(spec: DartClassSpec, writer: CodeWriter) {
+    private fun writeClassHeader(spec: ClassSpec, writer: CodeWriter) {
         when (val type = spec.classType) {
             ClassType.CLASS, ClassType.MIXIN, ClassType.ENUM -> {
                 writer.emit(type.keyword)
@@ -150,7 +150,7 @@ class ClassWriter {
         writer.emit("·")
     }
 
-    private fun writeInheritance(spec: DartClassSpec, writer: CodeWriter) {
+    private fun writeInheritance(spec: ClassSpec, writer: CodeWriter) {
         if (spec.superClass.orEmpty().trim().isNotEmpty()) {
             writer.emit("${spec.inheritKeyWord!!.identifier}·")
             writer.emit("${spec.superClass!!}·")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
@@ -1,7 +1,7 @@
 package net.theevilreaper.dartpoet.code.writer
 
 import net.theevilreaper.dartpoet.DartFile
-import net.theevilreaper.dartpoet.clazz.DartClassSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.emitExtensions
 import net.theevilreaper.dartpoet.code.emitProperties
@@ -51,7 +51,7 @@ class DartFileWriter {
 
         if (dartFile.types.isNotEmpty()) {
             dartFile.types.forEach {
-                classWriter.write(it as DartClassSpec, writer)
+                classWriter.write(it as ClassSpec, writer)
                 if (dartFile.types.size > 1) {
                     writer.emit(NEW_LINE)
                 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
@@ -4,13 +4,13 @@ import net.theevilreaper.dartpoet.DartModifier.*
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.emitParameters
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.util.SEMICOLON
 import net.theevilreaper.dartpoet.util.toImmutableSet
 
 class FunctionWriter {
 
-    fun emit(functionSpec: DartFunctionSpec, writer: CodeWriter) {
+    fun emit(functionSpec: FunctionSpec, writer: CodeWriter) {
         if (functionSpec.hasDocs) {
             functionSpec.docs.forEach { writer.emitDoc(it) }
         }
@@ -72,7 +72,7 @@ class FunctionWriter {
         }
     }
 
-    private fun writeBody(spec: DartFunctionSpec, writer: CodeWriter) {
+    private fun writeBody(spec: FunctionSpec, writer: CodeWriter) {
         if (spec.body.isEmpty()) {
             writer.emit(SEMICOLON)
             return
@@ -93,7 +93,7 @@ class FunctionWriter {
         }
     }
 
-    private fun writeTypeDef(spec: DartFunctionSpec, codeWriter: CodeWriter) {
+    private fun writeTypeDef(spec: FunctionSpec, codeWriter: CodeWriter) {
         codeWriter.emit("${TYPEDEF.identifier}·")
         codeWriter.emit("${spec.name}·")
         codeWriter.emit("=·")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
@@ -3,14 +3,14 @@ package net.theevilreaper.dartpoet.code.writer
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.emitAnnotations
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import net.theevilreaper.dartpoet.util.SEMICOLON
 import net.theevilreaper.dartpoet.util.SPACE
 
 class PropertyWriter {
 
-    fun write(property: DartPropertySpec, writer: CodeWriter) {
+    fun write(property: PropertySpec, writer: CodeWriter) {
         if (property.hasDocs) {
             property.docs.forEach { writer.emitDoc(it) }
         }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionBuilder.kt
@@ -1,7 +1,7 @@
 package net.theevilreaper.dartpoet.extension
 
 import net.theevilreaper.dartpoet.code.CodeBlock
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 
 /**
  * @since 1.0.0
@@ -12,7 +12,7 @@ class ExtensionBuilder(
     val extClass: String
 ) {
     internal var endWithNewLine: Boolean = false
-    internal val functionStack: MutableList<DartFunctionSpec> = mutableListOf()
+    internal val functionStack: MutableList<FunctionSpec> = mutableListOf()
     internal val docs: MutableList<CodeBlock> = mutableListOf()
 
     /**
@@ -26,26 +26,26 @@ class ExtensionBuilder(
     }
 
     /**
-     * Add a new [DartFunctionSpec] to the extension.
+     * Add a new [FunctionSpec] to the extension.
      * @param function the function to add
      */
-    fun function(function: DartFunctionSpec) = apply {
+    fun function(function: FunctionSpec) = apply {
         this.functionStack += function
     }
 
     /**
-     * Add a new [DartFunctionSpec] to the extension.
+     * Add a new [FunctionSpec] to the extension.
      * @param function the function to add
      */
-    fun function(function: () -> DartFunctionSpec) = apply {
+    fun function(function: () -> FunctionSpec) = apply {
         this.functionStack += function()
     }
 
     /**
-     * Add a multiple [DartFunctionSpec] to the extension.
+     * Add a multiple [FunctionSpec] to the extension.
      * @param functions the functions to add
      */
-    fun functions(vararg functions: DartFunctionSpec) = apply {
+    fun functions(vararg functions: FunctionSpec) = apply {
         this.functionStack += functions
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -8,13 +8,13 @@ import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.parameter.DartParameterSpec
 
 /**
- * The builder class allows the creation of an [DartFunctionBuilder] without any effort.
+ * The builder class allows the creation of an [FunctionBuilder] without any effort.
  * @author 1.0.0
  * @since 1.0.0
  */
-class DartFunctionBuilder internal constructor(
+class FunctionBuilder internal constructor(
     val name: String,
-) : SpecMethods<DartFunctionBuilder> {
+) : SpecMethods<FunctionBuilder> {
 
     internal val specData: SpecData = SpecData()
     internal val parameters: MutableList<DartParameterSpec> = mutableListOf()
@@ -149,10 +149,10 @@ class DartFunctionBuilder internal constructor(
     }
 
     /**
-     * Constructs a new reference from the [DartFunctionSpec].
+     * Constructs a new reference from the [FunctionSpec].
      * @return the created instance
      */
-    fun build(): DartFunctionSpec {
+    fun build(): FunctionSpec {
         //Check if the return type contains a nullable char and remove that and change nullable to true
         if (returnType != null && returnType!!.endsWith("?")) {
             println("Found nullable char at the last position. Updating returnType")
@@ -168,6 +168,6 @@ class DartFunctionBuilder internal constructor(
             specData.modifiers.remove(DartModifier.TYPEDEF)
         }
 
-        return DartFunctionSpec(this)
+        return FunctionSpec(this)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -19,8 +19,8 @@ import net.theevilreaper.dartpoet.util.toImmutableSet
  * @since 1.0.0
  * @version 1.0.0
  */
-class DartFunctionSpec(
-    builder: DartFunctionBuilder
+class FunctionSpec(
+    builder: FunctionBuilder
 ) {
 
     internal val name = builder.name
@@ -81,10 +81,10 @@ class DartFunctionSpec(
     companion object {
 
         /**
-         * Static method to create a new instance from the [DartFunctionBuilder].
+         * Static method to create a new instance from the [FunctionBuilder].
          * @return the created instance
          */
         @JvmStatic
-        fun builder(name: String) = DartFunctionBuilder(name)
+        fun builder(name: String) = FunctionBuilder(name)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertyBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertyBuilder.kt
@@ -10,7 +10,7 @@ import net.theevilreaper.dartpoet.code.CodeBlock
  * @version 1.0.0
  * @since 1.0.0
  **/
-class DartPropertyBuilder internal constructor(
+class PropertyBuilder internal constructor(
     var name: String,
     var type: String,
 ) {
@@ -31,11 +31,11 @@ class DartPropertyBuilder internal constructor(
     }
 
     /**
-     * Apply a given format which contains the parts for the init block of the [DartPropertySpec].
+     * Apply a given format which contains the parts for the init block of the [PropertySpec].
      * @param format the given format
      * @param args the arguments for the format
      */
-    fun initWith(format: String, vararg args: Any?): DartPropertyBuilder = apply {
+    fun initWith(format: String, vararg args: Any?): PropertyBuilder = apply {
         this.initBlock.add(format, *args)
     }
 
@@ -43,7 +43,7 @@ class DartPropertyBuilder internal constructor(
      * Set the initializer block directly as [CodeBlock.Builder] to the property.
      * @param codeFragment the [CodeBlock.Builder] to set
      */
-    fun initWith(codeFragment: CodeBlock.Builder): DartPropertyBuilder = apply {
+    fun initWith(codeFragment: CodeBlock.Builder): PropertyBuilder = apply {
         this.initBlock = codeFragment
     }
 
@@ -51,7 +51,7 @@ class DartPropertyBuilder internal constructor(
      * Set if the property should be nullable or not. A property which is nullable in Dart contains a '?' after the type.
      * @param nullable if the property should be nullable or not
      */
-    fun nullable(nullable: Boolean): DartPropertyBuilder {
+    fun nullable(nullable: Boolean): PropertyBuilder {
         this.nullable = nullable
         return this
     }
@@ -60,7 +60,7 @@ class DartPropertyBuilder internal constructor(
      * Add a [Iterable] of [AnnotationSpec] to the property.
      * @param annotations the annotations to add
      */
-    fun annotations(annotations: Iterable<AnnotationSpec>): DartPropertyBuilder = apply {
+    fun annotations(annotations: Iterable<AnnotationSpec>): PropertyBuilder = apply {
         this.annotations += annotations
     }
 
@@ -68,7 +68,7 @@ class DartPropertyBuilder internal constructor(
      * Add a [Iterable] of [AnnotationSpec] to the property.
      * @param annotations the annotations to add
      */
-    fun annotations(annotations: () -> Iterable<AnnotationSpec>): DartPropertyBuilder = apply {
+    fun annotations(annotations: () -> Iterable<AnnotationSpec>): PropertyBuilder = apply {
         this.annotations += annotations()
     }
 
@@ -76,7 +76,7 @@ class DartPropertyBuilder internal constructor(
      * Add a single [AnnotationSpec] to the property.
      * @param annotation the annotation to add
      */
-    fun annotation(annotation: () -> AnnotationSpec): DartPropertyBuilder = apply {
+    fun annotation(annotation: () -> AnnotationSpec): PropertyBuilder = apply {
         this.annotations += annotation()
     }
 
@@ -84,7 +84,7 @@ class DartPropertyBuilder internal constructor(
      * Add a single [AnnotationSpec] to the property.
      * @param annotation the annotation to add
      */
-    fun annotation(annotation: AnnotationSpec): DartPropertyBuilder = apply {
+    fun annotation(annotation: AnnotationSpec): PropertyBuilder = apply {
         this.annotations += annotation
     }
 
@@ -92,7 +92,7 @@ class DartPropertyBuilder internal constructor(
      * Add a new [DartModifier] to the property.
      * @param modifier the modifier to add
      */
-    fun modifier(modifier: DartModifier): DartPropertyBuilder = apply {
+    fun modifier(modifier: DartModifier): PropertyBuilder = apply {
         this.modifiers += modifier
     }
 
@@ -100,7 +100,7 @@ class DartPropertyBuilder internal constructor(
      * Add a new [DartModifier] to the property.
      * @param modifier the modifier to add
      */
-    fun modifier(modifier: () -> DartModifier): DartPropertyBuilder = apply {
+    fun modifier(modifier: () -> DartModifier): PropertyBuilder = apply {
         this.modifiers += modifier()
     }
 
@@ -108,7 +108,7 @@ class DartPropertyBuilder internal constructor(
      * Add a [Iterable] of [DartModifier] to the property.
      * @param modifiers the modifiers to add
      */
-    fun modifiers(modifiers: Iterable<DartModifier>): DartPropertyBuilder = apply {
+    fun modifiers(modifiers: Iterable<DartModifier>): PropertyBuilder = apply {
         this.modifiers += modifiers
     }
 
@@ -116,15 +116,15 @@ class DartPropertyBuilder internal constructor(
      * Add a [Iterable] of [DartModifier] to the property.
      * @param modifiers the modifiers to add
      */
-    fun modifiers(modifiers: () -> Iterable<DartModifier>): DartPropertyBuilder = apply {
+    fun modifiers(modifiers: () -> Iterable<DartModifier>): PropertyBuilder = apply {
         this.modifiers += modifiers()
     }
 
     /**
-     * Creates a new reference from the [DartPropertySpec] with the given builder reference.
-     * @return the created [DartPropertySpec] instance
+     * Creates a new reference from the [PropertySpec] with the given builder reference.
+     * @return the created [PropertySpec] instance
      */
-    fun build(): DartPropertySpec {
-        return DartPropertySpec(this)
+    fun build(): PropertySpec {
+        return PropertySpec(this)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
@@ -10,13 +10,13 @@ import net.theevilreaper.dartpoet.util.ALLOWED_PROPERTY_MODIFIERS
 import net.theevilreaper.dartpoet.util.hasAllowedModifiers
 
 /**
- * The property spec class contains all variables which are comes from the [DartPropertyBuilder].
+ * The property spec class contains all variables which are comes from the [PropertyBuilder].
  * Some values are checked for certain conditions to avoid errors during the generation.
  * @author theEvilReaper
  * @since 1.0.0
  */
-class DartPropertySpec(
-    builder: DartPropertyBuilder
+class PropertySpec(
+    builder: PropertyBuilder
 ) {
     internal var name = builder.name
     internal var type = builder.type
@@ -58,7 +58,7 @@ class DartPropertySpec(
     companion object {
 
         /**
-         * Creates a new instance from the [DartPropertyBuilder].
+         * Creates a new instance from the [PropertyBuilder].
          * The modifier parameter is optional
          */
         @JvmStatic
@@ -66,11 +66,11 @@ class DartPropertySpec(
             name: String,
             type: String,
             vararg modifiers: DartModifier = emptyArray()
-        ): DartPropertyBuilder {
-            return DartPropertyBuilder(name, type).modifiers { listOf(*modifiers) }
+        ): PropertyBuilder {
+            return PropertyBuilder(name, type).modifiers { listOf(*modifiers) }
         }
 
         @JvmStatic
-        fun constBuilder(name: String) = DartPropertyBuilder(name, "CONST").modifier(DartModifier.CONST)
+        fun constBuilder(name: String) = PropertyBuilder(name, "CONST").modifier(DartModifier.CONST)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -2,17 +2,17 @@ package net.theevilreaper.dartpoet
 
 import com.google.common.truth.Truth.*
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
-import net.theevilreaper.dartpoet.clazz.DartClassSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.buildCodeBlock
 import net.theevilreaper.dartpoet.enum.EnumPropertySpec
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.directive.DartDirective
 import net.theevilreaper.dartpoet.directive.CastType
 import net.theevilreaper.dartpoet.directive.LibraryDirective
 import net.theevilreaper.dartpoet.directive.PartDirective
 import net.theevilreaper.dartpoet.parameter.DartParameterSpec
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.lang.IllegalArgumentException
@@ -35,7 +35,7 @@ class DartFileTest {
 
     @Test
     fun `write test model with freezed`() {
-        val versionFreezedClass = DartClassSpec.builder("VersionModel")
+        val versionFreezedClass = ClassSpec.builder("VersionModel")
             .withMixin("_${'$'}VersionModel")
             .annotation { AnnotationSpec.builder("freezed").build() }
             .constructor {
@@ -101,10 +101,10 @@ class DartFileTest {
     fun `test library write`() {
         val libClass = DartFile.builder("testLib")
             .type(
-                DartClassSpec.anonymousClassBuilder()
+                ClassSpec.anonymousClassBuilder()
                     .endWithNewLine(true)
                     .function(
-                        DartFunctionSpec.builder("JsonMap")
+                        FunctionSpec.builder("JsonMap")
                             .typedef(true)
                             .returns("Map<String, dynamic>")
                             .build()
@@ -135,11 +135,11 @@ class DartFileTest {
     fun `test enum class write`() {
         val enumClass = DartFile.builder("navigation_entry")
             .type(
-                DartClassSpec.enumClass("NavigationEntry")
+                ClassSpec.enumClass("NavigationEntry")
                     .properties(
-                        DartPropertySpec.builder("name", "String")
+                        PropertySpec.builder("name", "String")
                             .modifier { DartModifier.FINAL }.build(),
-                        DartPropertySpec.builder("route", "String")
+                        PropertySpec.builder("route", "String")
                             .modifier { DartModifier.FINAL }.build()
 
                     )
@@ -187,8 +187,8 @@ class DartFileTest {
         val className = "DefectApi"
         val apiClient = "ApiClient"
 
-        val handlerApiClass = DartClassSpec.builder(className)
-            .property(DartPropertySpec.builder(apiClient.replaceFirstChar { it.lowercase() }, apiClient)
+        val handlerApiClass = ClassSpec.builder(className)
+            .property(PropertySpec.builder(apiClient.replaceFirstChar { it.lowercase() }, apiClient)
                 .modifier { DartModifier.FINAL }
                 .build()
             )
@@ -206,7 +206,7 @@ class DartFileTest {
                     .build()
             )
             .function(
-                DartFunctionSpec.builder("getByID")
+                FunctionSpec.builder("getByID")
                     .async(true)
                     .returns("DefectDTO")
                     .parameter(DartParameterSpec.builder("id", "int").build())
@@ -263,10 +263,10 @@ class DartFileTest {
     fun `test model class write`() {
         val name = "HousePart"
         val serializer = "standardSerializers"
-        val modelClass = DartClassSpec.abstractClass(name)
+        val modelClass = ClassSpec.abstractClass(name)
             .withImplements("Built<$name, ${name}Builder>")
             .function(
-                DartFunctionSpec.builder("serializer")
+                FunctionSpec.builder("serializer")
                     .returns("Serializer<$name>")
                     .lambda(true)
                     .getter(true)
@@ -275,7 +275,7 @@ class DartFileTest {
                     .build()
             )
             .function(
-                DartFunctionSpec.builder("fromJson")
+                FunctionSpec.builder("fromJson")
                     .lambda(true)
                     .returns(name)
                     .modifier(DartModifier.STATIC)
@@ -286,7 +286,7 @@ class DartFileTest {
                     .build()
             )
             .function(
-                DartFunctionSpec.builder("toJson")
+                FunctionSpec.builder("toJson")
                     .lambda(true)
                     .returns("dynamic")
                     .addCode(buildCodeBlock {
@@ -315,12 +315,12 @@ class DartFileTest {
         val classFile = DartFile.builder(name)
             .directive(DartDirective("dart:html"))
             .constants(
-                DartPropertySpec.constBuilder("typeLive").initWith("1").build(),
-                DartPropertySpec.constBuilder("typeTest").initWith("10").build(),
-                DartPropertySpec.constBuilder("typeDev").initWith("100").build(),
+                PropertySpec.constBuilder("typeLive").initWith("1").build(),
+                PropertySpec.constBuilder("typeTest").initWith("10").build(),
+                PropertySpec.constBuilder("typeDev").initWith("100").build(),
             )
             .type(
-                DartClassSpec.builder(name.replaceFirstChar { it.uppercase() })
+                ClassSpec.builder(name.replaceFirstChar { it.uppercase() })
                     .annotation(AnnotationSpec.builder("freezed").build())
             )
             .build()
@@ -344,7 +344,7 @@ class DartFileTest {
             .doc("Hallo")
             .doc("This is a [%L]", "Test")
             .type(
-                DartClassSpec.builder("Test")
+                ClassSpec.builder("Test")
             )
             .build()
         assertThat(clazz.toString()).isEqualTo(
@@ -358,9 +358,9 @@ class DartFileTest {
 
     @Test
     fun `test class with a bunch of comments`() {
-        val spec = DartClassSpec.builder("TestModel")
+        val spec = ClassSpec.builder("TestModel")
             .property {
-                DartPropertySpec.builder("name", "String")
+                PropertySpec.builder("name", "String")
                     .docs("Property comment")
                     .build()
             }
@@ -371,7 +371,7 @@ class DartFileTest {
                     .build()
             )
             .function(
-                DartFunctionSpec.builder("getName")
+                FunctionSpec.builder("getName")
                     .doc("Returns the given name from the object")
                     .returns("String")
                     .addCode(buildCodeBlock {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/PropertySpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/PropertySpecTest.kt
@@ -1,36 +1,36 @@
 package net.theevilreaper.dartpoet
 
 import com.google.common.truth.Truth.assertThat
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
-class DartPropertySpecTest {
+class PropertySpecTest {
 
     companion object {
 
         @JvmStatic
         fun parameters() = Stream.of(
             Arguments.of(
-                DartPropertySpec.builder("test", "String").nullable(true).build(),
+                PropertySpec.builder("test", "String").nullable(true).build(),
                 "String? test;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("value", "int").build(),
+                PropertySpec.builder("value", "int").build(),
                 "int value;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("data", "int").initWith("%L", "4").build(),
+                PropertySpec.builder("data", "int").initWith("%L", "4").build(),
                 "int data = 4;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("data", "int").initWith("%L", "4").modifier { DartModifier.FINAL }.build(),
+                PropertySpec.builder("data", "int").initWith("%L", "4").modifier { DartModifier.FINAL }.build(),
                 "final int data = 4;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("id", "String").modifiers { listOf(DartModifier.FINAL, DartModifier.PRIVATE) }.build(),
+                PropertySpec.builder("id", "String").modifiers { listOf(DartModifier.FINAL, DartModifier.PRIVATE) }.build(),
                 "final String _id;"
             )
         )
@@ -38,7 +38,7 @@ class DartPropertySpecTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    fun `test properties`(propertySpec: DartPropertySpec, expected: String) {
+    fun `test properties`(propertySpec: PropertySpec, expected: String) {
         assertThat(propertySpec.toString()).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/AbstractClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/AbstractClassTest.kt
@@ -2,8 +2,8 @@ package net.theevilreaper.dartpoet.classTypes
 
 import com.google.common.truth.Truth.*
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
-import net.theevilreaper.dartpoet.clazz.DartClassSpec
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.parameter.DartParameterSpec
 import org.junit.jupiter.api.Test
 
@@ -11,14 +11,14 @@ class AbstractClassTest {
 
     @Test
     fun `test simple abstract class`() {
-        val abstractClass = DartClassSpec.abstractClass("DatabaseHandler")
+        val abstractClass = ClassSpec.abstractClass("DatabaseHandler")
             .endWithNewLine(true)
-            .function(DartFunctionSpec.builder("getByID")
+            .function(FunctionSpec.builder("getByID")
                 .returns("TestModel")
                 .parameter(DartParameterSpec.builder("id", "int").build())
                 .build()
             )
-            .function(DartFunctionSpec.builder("test").build())
+            .function(FunctionSpec.builder("test").build())
             .build()
 
         assertThat(abstractClass.toString()).isEqualTo(
@@ -36,11 +36,11 @@ class AbstractClassTest {
 
     @Test
     fun `test abstract class with annotation`() {
-        val abstractClass = DartClassSpec.abstractClass("Test")
+        val abstractClass = ClassSpec.abstractClass("Test")
             .annotation(
                 AnnotationSpec.builder("abc").build()
             )
-            .function(DartFunctionSpec.builder("test").build())
+            .function(FunctionSpec.builder("test").build())
             .build()
         assertThat(abstractClass.toString()).isEqualTo(
             """

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
@@ -2,8 +2,8 @@ package net.theevilreaper.dartpoet.code.writer
 
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartModifier
-import net.theevilreaper.dartpoet.clazz.DartClassSpec
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -16,18 +16,18 @@ class ClassWriterTest {
 
         @JvmStatic
         private fun simpleClasses() = Stream.of(
-            Arguments.of(DartClassSpec.builder("Test").build(), "class Test {}"),
-            Arguments.of(DartClassSpec.mixinClass("Test").build(), "mixin Test {}"),
-            Arguments.of(DartClassSpec.enumClass("Test").build(), "enum Test {}"),
+            Arguments.of(ClassSpec.builder("Test").build(), "class Test {}"),
+            Arguments.of(ClassSpec.mixinClass("Test").build(), "mixin Test {}"),
+            Arguments.of(ClassSpec.enumClass("Test").build(), "enum Test {}"),
             Arguments.of(
-                DartClassSpec.builder("Model").endWithNewLine(true).build(),
+                ClassSpec.builder("Model").endWithNewLine(true).build(),
                 """
                 class Model {}
                 
                 """.trimIndent()
             ),
             Arguments.of(
-                DartClassSpec.abstractClass("DatabaseHandler").endWithNewLine(true).build(),
+                ClassSpec.abstractClass("DatabaseHandler").endWithNewLine(true).build(),
                 """
                 abstract class DatabaseHandler {}
                 
@@ -38,19 +38,19 @@ class ClassWriterTest {
 
     @ParameterizedTest
     @MethodSource("simpleClasses")
-    fun `test simple classes`(classSpec: DartClassSpec, expected: String) {
+    fun `test simple classes`(classSpec: ClassSpec, expected: String) {
         assertThat(classSpec.toString()).isEqualTo(expected)
     }
 
     @Test
     fun `test class writing with some constants`() {
-        val clazz = DartClassSpec.builder("TestClass")
+        val clazz = ClassSpec.builder("TestClass")
             .constants(
-                DartPropertySpec.builder("test", "String")
+                PropertySpec.builder("test", "String")
                     .modifiers { listOf(DartModifier.STATIC, DartModifier.CONST) }
                     .initWith("%C", "Test")
                     .build(),
-                DartPropertySpec.builder("maxId", "int")
+                PropertySpec.builder("maxId", "int")
                     .modifiers { listOf(DartModifier.CONST, DartModifier.STATIC) }
                     .initWith("%L", "100")
                     .build(),

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
@@ -3,7 +3,7 @@ package net.theevilreaper.dartpoet.code.writer
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -62,7 +62,7 @@ class ExtensionWriterTest {
     fun `test simple extension with method`() {
         val extension = ExtensionSpec.builder("TestExtension", "String")
             .function {
-                DartFunctionSpec.builder("hasSize")
+                FunctionSpec.builder("hasSize")
                     .returns("bool")
                     .addCode(CodeBlock.of(
                         "return this.length > 2;"

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -1,7 +1,7 @@
 package net.theevilreaper.dartpoet.code.writer
 
 import net.theevilreaper.dartpoet.DartModifier
-import net.theevilreaper.dartpoet.function.DartFunctionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import org.junit.jupiter.api.Test
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.code.CodeBlock
@@ -13,7 +13,7 @@ class FunctionWriterTest {
 
     @Test
     fun `write void method`() {
-        val method = DartFunctionSpec.builder("test")
+        val method = FunctionSpec.builder("test")
             .returns("void")
             .build()
         assertThat(method.toString()).isEqualTo("void test();")
@@ -22,7 +22,7 @@ class FunctionWriterTest {
     @Test
     fun `write simple method without parameters`() {
         val writer = CodeWriter(StringBuilder())
-        val method = DartFunctionSpec.builder("getName")
+        val method = FunctionSpec.builder("getName")
             .modifier(DartModifier.PUBLIC)
             .returns("String")
             .addCode("return %C;", "test")
@@ -41,7 +41,7 @@ class FunctionWriterTest {
     @Test
     fun `test simple private method`() {
         val writer = CodeWriter(StringBuilder())
-        val method = DartFunctionSpec.builder("name")
+        val method = FunctionSpec.builder("name")
             .returns("String")
             .modifier(DartModifier.PRIVATE)
             .addCode("return %C;", "Tobi").build()
@@ -57,7 +57,7 @@ class FunctionWriterTest {
 
     @Test
     fun `write simple nullable function`() {
-        val method = DartFunctionSpec.builder("getId")
+        val method = FunctionSpec.builder("getId")
             .returns("int")
             .nullable(true)
             .addCode("return %L;", 10).build()
@@ -72,7 +72,7 @@ class FunctionWriterTest {
 
     @Test
     fun `write another nullable method`() {
-        val method = DartFunctionSpec.builder("getValue")
+        val method = FunctionSpec.builder("getValue")
             .returns("int?")
             .addCode("return 1;")
             .build()
@@ -87,7 +87,7 @@ class FunctionWriterTest {
 
     @Test
     fun `write simple async function`() {
-        val method = DartFunctionSpec.builder("getNameById")
+        val method = FunctionSpec.builder("getNameById")
             .returns("String")
             .async(true)
             .parameter {
@@ -109,7 +109,7 @@ class FunctionWriterTest {
 
     @Test
     fun `write method with two parameters`() {
-        val method = DartFunctionSpec.builder("getAllById")
+        val method = FunctionSpec.builder("getAllById")
             .returns("List<Model>")
             .parameters {
                 listOf(
@@ -127,7 +127,7 @@ class FunctionWriterTest {
 
     @Test
     fun `test typedef write`() {
-        val function = DartFunctionSpec.builder("ValueUpdate<E>")
+        val function = FunctionSpec.builder("ValueUpdate<E>")
             .typedef(true)
             .parameter(DartParameterSpec.builder("value", "E")
                 .nullable(true).build())
@@ -138,7 +138,7 @@ class FunctionWriterTest {
 
     @Test
     fun `test cast write`() {
-        val function = DartFunctionSpec.builder("getId")
+        val function = FunctionSpec.builder("getId")
             .returns("int")
             .typeCast("int")
             .build()
@@ -147,7 +147,7 @@ class FunctionWriterTest {
 
     @Test
     fun `test other getter variant write`() {
-        val function = DartFunctionSpec.builder("value")
+        val function = FunctionSpec.builder("value")
             .returns("int")
             .getter(true)
             .addCode("%L", "_value;")
@@ -157,7 +157,7 @@ class FunctionWriterTest {
 
     @Test
     fun `test other setter variant write`() {
-        val function = DartFunctionSpec.builder("value")
+        val function = FunctionSpec.builder("value")
             .parameter(
                 DartParameterSpec.builder("value", "int")
                     .build()
@@ -178,7 +178,7 @@ class FunctionWriterTest {
 
     @Test
     fun `test lambda method write`() {
-        val function = DartFunctionSpec.builder("isNoble")
+        val function = FunctionSpec.builder("isNoble")
             .lambda(true)
             .parameter(DartParameterSpec.builder("atomicNumber", "int").build())
             .returns("bool")
@@ -189,7 +189,7 @@ class FunctionWriterTest {
 
     @Test
     fun `test method with documentation`() {
-        val function = DartFunctionSpec.builder("getName")
+        val function = FunctionSpec.builder("getName")
             .returns("String")
             .addCode("return %C;", "Test")
             .doc("Returns the name from an object")

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
@@ -3,7 +3,7 @@ package net.theevilreaper.dartpoet.code.writer
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
-import net.theevilreaper.dartpoet.property.DartPropertySpec
+import net.theevilreaper.dartpoet.property.PropertySpec
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -17,27 +17,27 @@ class PropertyWriterTest {
 
         @JvmStatic
         private fun simpleProperties(): Stream<Arguments> = Stream.of(
-            Arguments.of(DartPropertySpec.builder("id", "int").build(), "int id;"),
-            Arguments.of(DartPropertySpec.builder("id", "String")
+            Arguments.of(PropertySpec.builder("id", "int").build(), "int id;"),
+            Arguments.of(PropertySpec.builder("id", "String")
                 .nullable(true)
                 .build(),
                 "String? id;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("test", "String")
+                PropertySpec.builder("test", "String")
                     .modifier { DartModifier.PRIVATE }
                     .nullable(true)
                     .build(),
                 "String? _test;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("abc", "String")
+                PropertySpec.builder("abc", "String")
                     .modifier { DartModifier.LATE }
                     .build(),
                 "late String abc;"
             ),
             Arguments.of(
-                DartPropertySpec.builder("age", "int")
+                PropertySpec.builder("age", "int")
                     .initWith("%L", "12")
                     .build(),
                 "int age = 12;"
@@ -47,13 +47,13 @@ class PropertyWriterTest {
 
     @ParameterizedTest
     @MethodSource("simpleProperties")
-    fun `test simple properties`(propertySpec: DartPropertySpec, expected: String) {
+    fun `test simple properties`(propertySpec: PropertySpec, expected: String) {
         assertEquals(expected, propertySpec.toString())
     }
 
     @Test
     fun `write const property`() {
-        val property = DartPropertySpec.builder("maxID", "int")
+        val property = PropertySpec.builder("maxID", "int")
             .modifiers { listOf(DartModifier.STATIC, DartModifier.CONST) }
             .initWith("%L", "1000")
             .build()
@@ -62,7 +62,7 @@ class PropertyWriterTest {
 
     @Test
     fun `write simple variable with one annotation`() {
-        val property = DartPropertySpec.builder("age", "int")
+        val property = PropertySpec.builder("age", "int")
             .annotation { AnnotationSpec.builder("jsonIgnore").build() }
             .initWith("%L", "12")
             .build()
@@ -76,7 +76,7 @@ class PropertyWriterTest {
 
     @Test
     fun `write property with annotations`() {
-        val property = DartPropertySpec.builder("description", "String")
+        val property = PropertySpec.builder("description", "String")
             .nullable(true)
             .annotation {
                 AnnotationSpec.builder("JsonKey")
@@ -94,7 +94,7 @@ class PropertyWriterTest {
 
     @Test
     fun `test property with comment`() {
-        val property = DartPropertySpec.builder("name", "String")
+        val property = PropertySpec.builder("name", "String")
             .nullable(true)
             .docs("Represents the name from something")
             .build()

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -4,13 +4,13 @@ import net.theevilreaper.dartpoet.DartModifier
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
-class DartFunctionSpecTest {
+class FunctionSpecTest {
 
     @Test
     fun `create function with empty name`() {
         assertThrows(
             IllegalArgumentException::class.java,
-            { DartFunctionSpec.builder(" ").build() },
+            { FunctionSpec.builder(" ").build() },
             "The name of a function can't be empty"
         )
     }
@@ -19,7 +19,7 @@ class DartFunctionSpecTest {
     fun `create invalid abstract method`() {
         assertThrows(
             IllegalArgumentException::class.java,
-            { DartFunctionSpec.builder("getName").modifier(DartModifier.ABSTRACT).addCode("%L", "value").build() },
+            { FunctionSpec.builder("getName").modifier(DartModifier.ABSTRACT).addCode("%L", "value").build() },
             "An abstract method can't have a body"
         )
     }


### PR DESCRIPTION
## Proposed changes

At the moment some spec structures contains a `Dart` prefix at the beginning of the file and classname. This is nice but i doesn't add any value to the project. The pull request removes from some structures the mentioned `Dart` prefix. Only the DartFile class keeps the naming for now. Without the prefix the name is only `File` and that creates some conflicts with the File class from the JDK.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...