### PR TITLE
Add indent check to prevent invalid indent usage

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
@@ -8,7 +8,7 @@ import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.directive.Directive
 import net.theevilreaper.dartpoet.property.DartPropertySpec
 import net.theevilreaper.dartpoet.util.DEFAULT_INDENT
-import java.lang.IllegalArgumentException
+import net.theevilreaper.dartpoet.util.isIndent
 
 class DartFileBuilder(
     val name: String
@@ -50,9 +50,7 @@ class DartFileBuilder(
     }
 
     fun indent(indent: String) = apply {
-        if (indent.trim().isEmpty()) {
-            throw IllegalArgumentException("The indent can't be empty")
-        }
+        check(isIndent(indent)) { "An indent can only contains only spaces" }
         this.indent = indent
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -30,8 +30,11 @@ internal val ALLOWED_FUNCTION_MODIFIERS = setOf(DartModifier.PUBLIC, DartModifie
 internal val ALLOWED_PROPERTY_MODIFIERS = setOf(DartModifier.PRIVATE, DartModifier.FINAL, DartModifier.LATE, DartModifier.STATIC, DartModifier.CONST)
 internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.STATIC, DartModifier.CONST)
 internal val ALLOWED_CONST_MODIFIERS = setOf(DartModifier.CONST)
+
+//RegEx
 private val namePattern: Regex = Regex("[a-z]+|([a-z]+)_+([a-z]+)")
 private val lowerCamelCase: Regex = Regex("[a-z]+[A-Z0-9]*[a-z0-9]*[A-Za-z0-9]*")
+private val indentPattern: Regex = Regex(" +")
 
 /**
  * Checks if a given set of [DartModifier] matches with a given set which contains the allowed [DartModifier].
@@ -67,5 +70,24 @@ fun isDartConventionFileName(fileName: String): Boolean {
  * @return true when the string has the format otherwise false
  */
 fun isInLowerCamelCase(input: String): Boolean {
-    return input.trim().isNotEmpty() && input.matches(lowerCamelCase)
+    return testStringForPattern(input, lowerCamelCase)
+}
+
+/**
+ * Checks if a given [String] can be used as an indent.
+ * @param input the string to check
+ * @return true when the string only contains spaces otherwise false
+ */
+fun isIndent(input: String): Boolean {
+    return testStringForPattern(input, indentPattern)
+}
+
+/**
+ * Add base method for all the method which tests a string for a pattern.
+ * @param input the string to check
+ * @param pattern the pattern for the check
+ * @return true when the string matches with the pattern otherwise false
+ */
+private fun testStringForPattern(input: String, pattern: Regex): Boolean {
+    return input.isNotEmpty() && input.matches(pattern)
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -22,13 +22,13 @@ class DartFileTest {
     @Test
     fun `test indent set`() {
         assertThrows(
-            IllegalArgumentException::class.java,
+            IllegalStateException::class.java,
             { DartFile.builder("Test").indent("") },
             "The indent can't be empty"
         )
         assertThrows(
-            IllegalArgumentException::class.java,
-            { DartFile.builder("Test").indent { "" } },
+            IllegalStateException::class.java,
+            { DartFile.builder("Test").indent { " 123AB" } },
             "The indent can't be empty"
         )
     }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/util/IndentTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/util/IndentTest.kt
@@ -1,0 +1,33 @@
+package net.theevilreaper.dartpoet.util
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IndentTest {
+
+    companion object {
+
+        @JvmStatic
+        private fun indentTest() = Stream.of(
+            Arguments.of(" ", true),
+            Arguments.of("  ", true),
+            Arguments.of("", false),
+            Arguments.of(" a", false),
+            Arguments.of("123", false),
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("indentTest")
+    fun `test indent pattern`(indent: String, expected: Boolean) {
+        if (expected) {
+            assertTrue { isIndent(indent) }
+        } else {
+            assertFalse { isIndent(indent) }
+        }
+    }
+}


### PR DESCRIPTION

## Proposed changes

The builder for the `DartFile` allows to change the used `indent` for the generation. But there is no check that prevents an indent from being set that contains more than spaces. So the pull request adds a check which checks if the new indent only contains spaces

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...