### PR TITLE
Add toBuilder function to the spec classes

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
@@ -132,6 +132,8 @@ class DartFile internal constructor(
         builder.annotations.addAll(this.annotations)
         builder.extensionStack.addAll(this.extensions)
         builder.constants.addAll(this.constants)
+        builder.docs.addAll(this.docs.toMutableList())
+        builder.indent = this.indent
         return builder
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/annotation/AnnotationSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/annotation/AnnotationSpec.kt
@@ -44,6 +44,16 @@ class AnnotationSpec(
      */
     override fun toString() = buildCodeString { write(this) }
 
+    /**
+     * Creates a new [AnnotationSpecBuilder] reference from an existing [AnnotationSpec] object.
+     * @return the created [AnnotationSpecBuilder] instance
+     */
+    fun toBuilder(): AnnotationSpecBuilder {
+        val builder = AnnotationSpecBuilder(this.name)
+        builder.content.addAll(this.content)
+        return builder
+    }
+
     companion object {
 
         /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
@@ -1,7 +1,6 @@
 package net.theevilreaper.dartpoet.code.writer
 
 import net.theevilreaper.dartpoet.DartFile
-import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.emitExtensions
 import net.theevilreaper.dartpoet.code.emitProperties
@@ -51,7 +50,7 @@ class DartFileWriter {
 
         if (dartFile.types.isNotEmpty()) {
             dartFile.types.forEach {
-                classWriter.write(it as ClassSpec, writer)
+                classWriter.write(it, writer)
                 if (dartFile.types.size > 1) {
                     writer.emit(NEW_LINE)
                 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/enum/EnumPropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/enum/EnumPropertySpec.kt
@@ -44,20 +44,17 @@ class EnumPropertySpec(
      * Creates a string representation from the spec object.
      * @return the created string
      */
-    override fun toString() = buildCodeString {
-        write(
-            this,
-        )
-    }
+    override fun toString() = buildCodeString { write(this) }
 
     /**
      * Converts a [EnumPropertySpec] to a [EnumPropertyWriter] instance.
      * @return the created instance
      */
     fun toBuilder(): EnumPropertyBuilder {
-        val builder = EnumPropertyBuilder(name)
-        builder.genericValueCast = generic
-        builder.parameters += parameters
+        val builder = EnumPropertyBuilder(this.name)
+        builder.annotations.addAll(this.annotations)
+        builder.genericValueCast = this.generic
+        builder.parameters.addAll(this.parameters)
         return builder
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
@@ -1,7 +1,5 @@
 package net.theevilreaper.dartpoet.extension
 
-import net.theevilreaper.dartpoet.annotation.AnnotationSpec
-import net.theevilreaper.dartpoet.annotation.AnnotationSpecBuilder
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.ExtensionWriter

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
@@ -1,5 +1,7 @@
 package net.theevilreaper.dartpoet.extension
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.annotation.AnnotationSpecBuilder
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.ExtensionWriter
@@ -45,6 +47,18 @@ class ExtensionSpec(
      * @return the created string representation
      */
     override fun toString() = buildCodeString { write(this) }
+
+    /**
+     * Creates a new [ExtensionBuilder] reference from an existing [ExtensionSpec] object.
+     * @return the created [ExtensionBuilder] instance
+     */
+    fun toBuilder(): ExtensionBuilder {
+        val builder = ExtensionBuilder(this.name, this.extClass)
+        builder.endWithNewLine = this.endWithNewLine
+        builder.docs.addAll(this.docs)
+        builder.functionStack.addAll(this.functions)
+        return builder
+    }
 
     companion object {
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -78,6 +78,29 @@ class FunctionSpec(
      */
     override fun toString() = buildCodeString { write(this) }
 
+    /**
+     * Creates a new [FunctionBuilder] reference from an existing [FunctionSpec] object.
+     * @return the created [FunctionBuilder] instance
+     */
+    fun toBuilder(): FunctionBuilder {
+        val builder = FunctionBuilder(this.name)
+        builder.returnType = this.returnType
+        builder.annotations(*this.annotation.toTypedArray())
+        builder.modifiers(*this.modifiers.toTypedArray())
+        builder.parameters.addAll(this.parameters)
+        builder.async = this.isAsync
+        builder.nullable = this.isNullable
+        builder.typedef = this.isTypeDef
+        builder.typeCast = this.typeCast
+        builder.setter = this.asSetter
+        builder.getter = this.isGetter
+        builder.lambda = this.isLambda
+        builder.body.formatParts.addAll(this.body.formatParts)
+        builder.body.args.add(this.body.args)
+        builder.docs.addAll(this.docs)
+        return builder
+    }
+
     companion object {
 
         /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/constructor/ConstructorSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/constructor/ConstructorSpec.kt
@@ -18,11 +18,12 @@ class ConstructorSpec(
     internal val initializer = builder.initializer
     internal val modifiers = builder.modifiers.toImmutableSet()
     private val modelParameters = builder.parameters.toImmutableSet()
-    internal val requiredAndNamedParameters = builder.parameters.filter { it.isRequired || it.isNamed }.toImmutableList()
+    internal val requiredAndNamedParameters =
+        builder.parameters.filter { it.isRequired || it.isNamed }.toImmutableList()
     internal val parameters = modelParameters.minus(requiredAndNamedParameters.toSet()).toImmutableList()
     internal val hasParameters = builder.parameters.isNotEmpty()
     internal val hasNamedParameters = requiredAndNamedParameters.isNotEmpty()
-    internal val docs = builder.docs
+    internal val docs = builder.docs.toImmutableList()
 
     internal fun write(
         codeWriter: CodeWriter
@@ -30,10 +31,26 @@ class ConstructorSpec(
         ConstructorWriter().emit(this, codeWriter)
     }
 
-    override fun toString() = buildCodeString {
-        write(
-            this,
-        )
+    override fun toString() = buildCodeString { write(this,) }
+
+    /**
+     * Creates a new [ConstructorBuilder] reference from an existing [ConstructorSpec] object.
+     * @return the created [ConstructorBuilder] instance
+     */
+    fun toBuilder(): ConstructorBuilder {
+        val builder = ConstructorBuilder(this.name, this.named)
+        builder.lambda = this.isLambda
+        builder.factory = this.isFactory
+        builder.modifiers.addAll(this.modifiers)
+        builder.parameters.addAll(this.modelParameters)
+
+        if (this.initializer.build().isNotEmpty()) {
+            builder.initializer.formatParts.addAll(this.initializer.formatParts)
+            builder.initializer.args.addAll(this.initializer.args)
+        }
+
+        builder.docs.addAll(this.docs)
+        return builder
     }
 
     companion object {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -41,6 +41,7 @@ class ParameterSpec internal constructor(
         builder.nullable = isNullable
         builder.required = isRequired
         builder.annotations(*this.annotations.toTypedArray())
+        builder.initializer = initializer
         return builder
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -25,26 +25,24 @@ class ParameterSpec internal constructor(
         }
     }
 
-    fun toBuilder(): ParameterBuilder {
-        val builder = ParameterBuilder(name, type)
-        builder.named = isNamed
-        builder.nullable = isNullable
-        builder.required = isRequired
-        return builder
-    }
-
-    internal fun write(
-        codeWriter: CodeWriter
-    ) {
+    internal fun write(codeWriter: CodeWriter) {
         ParameterWriter().write(this, codeWriter)
     }
 
-    override fun toString() = buildCodeString {
-        write(
-            this,
-        )
-    }
+    override fun toString() = buildCodeString { write(this) }
 
+    /**
+     * Creates a new [ParameterBuilder] reference from an existing [ParameterSpec] object.
+     * @return the created [ParameterBuilder] instance
+     */
+    fun toBuilder(): ParameterBuilder {
+        val builder = ParameterBuilder(this.name, this.type)
+        builder.named = isNamed
+        builder.nullable = isNullable
+        builder.required = isRequired
+        builder.annotations(*this.annotations.toTypedArray())
+        return builder
+    }
 
     companion object {
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
@@ -55,6 +55,21 @@ class PropertySpec(
      */
     override fun toString() = buildCodeString { write(this) }
 
+    /**
+     * Creates a new [PropertyBuilder] reference from an existing [PropertySpec] object.
+     * @return the created [PropertyBuilder] instance
+     */
+    fun toBuilder(): PropertyBuilder {
+        val builder = PropertyBuilder(this.name, this.type)
+        builder.modifiers.addAll(this.modifiers)
+        builder.annotations.addAll(this.annotations)
+        builder.nullable = this.nullable
+        builder.initBlock = this.initBlock
+        builder.docs.addAll(this.docs)
+        builder.modifiers.addAll(this.modifiers)
+        return builder
+    }
+
     companion object {
 
         /**

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -15,6 +15,7 @@ import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
 
 class DartFileTest {
 
@@ -33,6 +34,18 @@ class DartFileTest {
     }
 
     @Test
+    fun `test spec to builder conversation`() {
+        val dartFileSpec = DartFile.builder("TestClass")
+            .indent(" ")
+            .annotation(AnnotationSpec.builder("ignore").build())
+            .build()
+        val specAsBuilder = dartFileSpec.toBuilder()
+        assertEquals(dartFileSpec.name, specAsBuilder.name)
+        assertEquals(dartFileSpec.indent, specAsBuilder.indent)
+        assertContentEquals(dartFileSpec.annotations, specAsBuilder.annotations)
+    }
+
+    @Test
     fun `write test model with freezed`() {
         val versionFreezedClass = ClassSpec.builder("VersionModel")
             .withMixin("_${'$'}VersionModel")
@@ -45,11 +58,11 @@ class DartFileTest {
                         ParameterSpec.builder("version", "String")
                             .named(true)
                             .annotations(
-                                    AnnotationSpec.builder("JsonKey")
-                                        .content("name: %C", "version").build(),
-                                    AnnotationSpec.builder("Default")
-                                        .content("%C", "1.0.0").build()
-                                )
+                                AnnotationSpec.builder("JsonKey")
+                                    .content("name: %C", "version").build(),
+                                AnnotationSpec.builder("Default")
+                                    .content("%C", "1.0.0").build()
+                            )
                             .build()
                     }
                     .build()

--- a/src/test/kotlin/net/theevilreaper/dartpoet/PropertySpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/PropertySpecTest.kt
@@ -2,17 +2,21 @@ package net.theevilreaper.dartpoet
 
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.property.PropertySpec
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class PropertySpecTest {
 
     companion object {
 
         @JvmStatic
-        fun parameters() = Stream.of(
+        fun parameters(): Stream<Arguments> = Stream.of(
             Arguments.of(
                 PropertySpec.builder("test", "String").nullable(true).build(),
                 "String? test;"
@@ -30,7 +34,8 @@ class PropertySpecTest {
                 "final int data = 4;"
             ),
             Arguments.of(
-                PropertySpec.builder("id", "String").modifiers { listOf(DartModifier.FINAL, DartModifier.PRIVATE) }.build(),
+                PropertySpec.builder("id", "String").modifiers { listOf(DartModifier.FINAL, DartModifier.PRIVATE) }
+                    .build(),
                 "final String _id;"
             )
         )
@@ -40,5 +45,18 @@ class PropertySpecTest {
     @MethodSource("parameters")
     fun `test properties`(propertySpec: PropertySpec, expected: String) {
         assertThat(propertySpec.toString()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `test spec to builder conversation`() {
+        val propertySpec = PropertySpec.builder("amount", "int")
+            .nullable(true)
+            .build()
+        val specAsBuilder = propertySpec.toBuilder().modifier(DartModifier.FINAL)
+        assertNotNull(specAsBuilder)
+        assertEquals(propertySpec.name, specAsBuilder.name)
+        assertEquals(propertySpec.type, specAsBuilder.type)
+        assertEquals(propertySpec.nullable, specAsBuilder.nullable)
+        assertTrue { specAsBuilder.modifiers.isNotEmpty() }
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/annotation/AnnotationSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/annotation/AnnotationSpecTest.kt
@@ -1,7 +1,8 @@
 package net.theevilreaper.dartpoet.annotation
 
-import org.junit.Test
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 class AnnotationSpecTest {
@@ -26,5 +27,15 @@ class AnnotationSpecTest {
     fun `test simple annotation without content`() {
         val annotation = AnnotationSpec.builder("jsonIgnore").build()
         assertEquals(expectedAnnotation, annotation.toString())
+    }
+
+    @Test
+    fun `test toBuilder function`() {
+        val annotationSpec = AnnotationSpec.builder("jsonIgnore")
+            .content("ignore", "true")
+            .build()
+        val specAsBuilder = annotationSpec.toBuilder()
+        assertEquals(annotationSpec.name, specAsBuilder.name)
+        assertContentEquals(annotationSpec.content, specAsBuilder.content)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/enumeration/EnumPropertySpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/enumeration/EnumPropertySpecTest.kt
@@ -2,12 +2,15 @@ package net.theevilreaper.dartpoet.enumeration
 
 import com.google.common.truth.Truth
 import net.theevilreaper.dartpoet.enum.EnumPropertySpec
-import org.junit.Test
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class EnumPropertySpecTest {
 
@@ -33,8 +36,19 @@ class EnumPropertySpecTest {
     }
 
     @Test
-    fun `test simple enum value`() {
-        val enumValue = EnumPropertySpec.builder("test").build()
-
+    fun `test spec conversion to a builder`() {
+        val propertySpec = EnumPropertySpec
+            .builder("test")
+            .generic("String")
+            .parameter("%C", "/dashboard")
+            .build()
+        val specAsBuilder = propertySpec.toBuilder()
+        assertNotNull(specAsBuilder)
+        assertEquals(propertySpec.name, specAsBuilder.name)
+        assertEquals(propertySpec.generic, specAsBuilder.genericValueCast)
+        assertTrue { propertySpec.annotations.isEmpty() }
+        assertTrue { specAsBuilder.annotations.isEmpty() }
+        assertTrue { specAsBuilder.parameters.isNotEmpty() }
+        assertContentEquals(propertySpec.parameters, specAsBuilder.parameters)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpecTest.kt
@@ -1,0 +1,20 @@
+package net.theevilreaper.dartpoet.extension
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ExtensionSpecTest {
+
+    @Test
+    fun `test spec to builder conversation`() {
+        val extensionSpec = ExtensionSpec.builder("isEmpty", "String")
+            .endsWithNewLine(true)
+            .doc("%C", "This is a test line")
+            .build()
+        val specAsBuilder = extensionSpec.toBuilder()
+        assertEquals(extensionSpec.name, specAsBuilder.name)
+        assertEquals(extensionSpec.extClass, specAsBuilder.extClass)
+        assertTrue { specAsBuilder.docs.isNotEmpty() }
+        assertEquals(extensionSpec.endWithNewLine, specAsBuilder.endWithNewLine)
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -1,8 +1,12 @@
 package net.theevilreaper.dartpoet.function
 
 import net.theevilreaper.dartpoet.DartModifier
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class FunctionSpecTest {
 
@@ -24,12 +28,19 @@ class FunctionSpecTest {
         )
     }
 
-   /* @Test
-    fun `test invalid function creation with void and nullable`() {
-        assertThrows(
-            IllegalArgumentException::class.java,
-            { DartFunctionSpec.builder("test").nullable(true).build() },
-            "A void function can't be nullable"
-        )
-    }*/
+    @Test
+    fun `test spec to builder conversation`() {
+        val functionSpec = FunctionSpec.builder("getAmount")
+            .returns("int")
+            .async(false)
+            .nullable(true)
+            .addCode("return %L", "10")
+            .build()
+        val specAsBuilder = functionSpec.toBuilder()
+        assertEquals(functionSpec.name, specAsBuilder.name)
+        assertEquals(functionSpec.returnType, specAsBuilder.returnType)
+        assertFalse { specAsBuilder.async }
+        assertTrue { specAsBuilder.nullable }
+        assertTrue { specAsBuilder.body.isNotEmpty() }
+    }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/constructor/ConstructorSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/constructor/ConstructorSpecTest.kt
@@ -1,0 +1,16 @@
+package net.theevilreaper.dartpoet.function.constructor
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ConstructorSpecTest {
+    @Test
+    fun `test spec to builder conversation`() {
+        val constructorSpec = ConstructorSpec.builder("TestModel")
+            .asFactory(true)
+            .build()
+        val specAsBuilder = constructorSpec.toBuilder()
+        assertEquals(constructorSpec.name, specAsBuilder.name)
+        assertEquals(constructorSpec.isFactory, specAsBuilder.factory)
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
@@ -1,0 +1,25 @@
+package net.theevilreaper.dartpoet.parameter
+
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class ParameterSpecTest {
+
+    @Test
+    fun `test spec to builder conversation`() {
+        val parameterSpec = ParameterSpec.builder("amount", "int")
+            .nullable(true)
+            .initializer("%L", "10")
+            .annotation(AnnotationSpec.builder("nullable").build())
+            .build()
+        val specAsBuilder = parameterSpec.toBuilder()
+        assertNotNull(parameterSpec)
+        assertEquals(parameterSpec.name, specAsBuilder.name)
+        assertEquals(parameterSpec.type, specAsBuilder.type)
+        assertEquals(parameterSpec.isNullable, specAsBuilder.nullable)
+        assertTrue { specAsBuilder.initializer!!.isNotEmpty() }
+        assertContentEquals(parameterSpec.annotations, specAsBuilder.specData.annotations)
+    }
+}


### PR DESCRIPTION
## Proposed changes

When a spec object has been built by a builder, it cannot be modified anymore. This is because they are immutable. If modification is needed nonetheless, one must tediously transfer all the values from the object into a new Builder instance. The Pull Request adds a toBuilder method to each spec class , which takes care of this.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...