### PR TITLE
Update typeCast option from a method to use the TypeName structure

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
@@ -57,8 +57,8 @@ class FunctionWriter {
         }
         writer.emit("${if (functionSpec.isPrivate) PRIVATE.identifier else ""}${functionSpec.name}")
 
-        if (functionSpec.typeCast.orEmpty().trim().isNotEmpty()) {
-            writer.emitCode("<%L>", functionSpec.typeCast)
+        if (functionSpec.typeCast != null) {
+            writer.emitCode("<%T>", functionSpec.typeCast)
         }
 
         if (functionSpec.isGetter) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -28,7 +28,7 @@ class FunctionBuilder internal constructor(
     internal var returnType: TypeName? = null
     internal val body: CodeBlock.Builder = CodeBlock.builder()
     internal var typedef: Boolean = false
-    internal var typeCast: String? = null
+    internal var typeCast: TypeName? = null
     internal var setter: Boolean = false
     internal var getter: Boolean = false
     internal var lambda: Boolean = false
@@ -68,9 +68,32 @@ class FunctionBuilder internal constructor(
         this.getter = getter
     }
 
-    fun typeCast(cast: String) = apply {
-        this.typeCast = cast
-    }
+    /**
+     * This method allows to specify a type cast using a [TypeName] object.
+     * It sets the type cast for the current instance and returns the modified instance.
+     *
+     * @param cast the [TypeName] representing the type to cast to
+     * @return the involved builder instance
+     */
+    fun typeCast(cast: TypeName) = apply { this.typeCast = cast }
+
+    /**
+     * This method allows to specify a type cast using a [ClassName] object.
+     * It sets the type cast for the current instance and returns the modified instance.
+     *
+     * @param cast the [ClassName] representing the type to cast to
+     * @return the involved builder instance
+     */
+    fun typeCast(cast: ClassName) = apply { this.typeCast = cast }
+
+    /**
+     * This method allows to specify a type cast using a [KClass] object.
+     * It sets the type cast for the current instance and returns the modified instance.
+     *
+     * @param cast the [KClass] representing the type to cast to
+     * @return the involved builder instance
+     */
+    fun typeCast(cast: KClass<*>) = apply { this.typeCast = cast.asTypeName() }
 
     /**
      * If the function should be generated as typedef definition.

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -9,10 +9,38 @@ import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeBlock
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.DYNAMIC
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
 import net.theevilreaper.dartpoet.type.asClassName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 class FunctionWriterTest {
+
+    private companion object {
+
+        @JvmStatic
+        private fun castFunctionWrite() = Stream.of(
+            Arguments.of(
+                "int getId<int>();",
+                FunctionSpec.builder("getId").returns(Int::class).typeCast(Int::class).build()
+            ),
+            Arguments.of(
+                "List<Model> getModels<List<dynamic>>();",
+                FunctionSpec.builder("getModels").returns(List::class.parameterizedBy(ClassName("Model")))
+                    .typeCast(List::class.parameterizedBy(DYNAMIC))
+                    .build()
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("castFunctionWrite")
+    fun `test function write with cast typeNames`(expected: String, functionSpec:FunctionSpec) {
+        assertThat(functionSpec.toString()).isEqualTo(expected)
+    }
 
     @Test
     fun `write void method`() {
@@ -140,15 +168,6 @@ class FunctionWriterTest {
             .returns(ClassName("void Function"))
             .build()
         assertThat(function.toString()).isEqualTo("typedef ValueUpdate<E> = void Function(E? value);")
-    }
-
-    @Test
-    fun `test cast write`() {
-        val function = FunctionSpec.builder("getId")
-            .returns(Int::class)
-            .typeCast("int")
-            .build()
-        assertThat(function.toString()).isEqualTo("int getId<int>();")
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

This #54 pull request introduced a new structure to use a `TypeName` object to represent the type for `properties`, `parameters` and more. During the conversion the typeCast option for functions was forgotten to update. This pull request updates the typeCast usage to the `TypeName` structure.


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...