### PR TITLE
Update methods that take an Iterable as a parameter

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -21,7 +21,6 @@ import kotlin.reflect.KClass
 class FunctionBuilder internal constructor(
     val name: String,
 ) : SpecMethods<FunctionBuilder> {
-
     internal val specData: SpecData = SpecData()
     internal val parameters: MutableList<ParameterSpec> = mutableListOf()
     internal var async: Boolean = false
@@ -125,12 +124,8 @@ class FunctionBuilder internal constructor(
         this.parameters += parameter()
     }
 
-    fun parameters(parameterSpec: Iterable<ParameterSpec>) = apply {
-        this.parameters += parameterSpec
-    }
-
-    fun parameters(parameterSpec: () -> Iterable<ParameterSpec>) = apply {
-        this.parameters += parameterSpec()
+    fun parameters(vararg parameters: ParameterSpec) = apply {
+        this.parameters += parameters
     }
 
     override fun annotation(annotation: () -> AnnotationSpec) = apply {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertyBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertyBuilder.kt
@@ -48,22 +48,6 @@ class PropertyBuilder internal constructor(
     }
 
     /**
-     * Add a [Iterable] of [AnnotationSpec] to the property.
-     * @param annotations the annotations to add
-     */
-    fun annotations(annotations: Iterable<AnnotationSpec>): PropertyBuilder = apply {
-        this.annotations += annotations
-    }
-
-    /**
-     * Add a [Iterable] of [AnnotationSpec] to the property.
-     * @param annotations the annotations to add
-     */
-    fun annotations(annotations: () -> Iterable<AnnotationSpec>): PropertyBuilder = apply {
-        this.annotations += annotations()
-    }
-
-    /**
      * Add a single [AnnotationSpec] to the property.
      * @param annotation the annotation to add
      */
@@ -96,19 +80,11 @@ class PropertyBuilder internal constructor(
     }
 
     /**
-     * Add a [Iterable] of [DartModifier] to the property.
-     * @param modifiers the modifiers to add
+     * Add an [Array] of [DartModifier]'s to the property.
+     * @param modifiers the modifier values to add
      */
-    fun modifiers(modifiers: Iterable<DartModifier>): PropertyBuilder = apply {
+    fun modifiers(vararg modifiers: DartModifier) = apply {
         this.modifiers += modifiers
-    }
-
-    /**
-     * Add a [Iterable] of [DartModifier] to the property.
-     * @param modifiers the modifiers to add
-     */
-    fun modifiers(modifiers: () -> Iterable<DartModifier>): PropertyBuilder = apply {
-        this.modifiers += modifiers()
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

In an older version, all spec builders contain a method that takes an `Iterable` as a parameter to add something to the structure. A few of them have been removed or replaced with a method that takes `varargs` as a parameter. This pull request updates the parameter usage to a `varargs` type.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...