### PR TITLE
Fix invalid parameter generation when they are named or required

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
@@ -107,6 +107,30 @@ internal fun Set<ConstructorSpec>.emitConstructors(
     }
 }
 
+internal fun Set<ParameterSpec>.emitSpecialParameters(
+    codeWriter: CodeWriter,
+    emitSpace: Boolean = true,
+    emitAsRequired: Boolean,
+    emitBlock: (ParameterSpec) -> Unit = { it.write(codeWriter) }
+) = with(codeWriter) {
+    if (isNotEmpty()) {
+        emit(if (emitAsRequired) "$CURLY_OPEN" else "[")
+        val comma = size > 1
+        forEachIndexed { index, parameterSpec ->
+            emitBlock(parameterSpec)
+            if (comma) {
+                if (index < size - 1) {
+                    emit(",")
+                }
+                if (emitSpace && index < size - 1) {
+                    emit(SPACE)
+                }
+            }
+        }
+        emit(if (emitAsRequired) "$CURLY_CLOSE" else "]")
+    }
+}
+
 internal fun List<ParameterSpec>.emitParameters(
     codeWriter: CodeWriter,
     forceNewLines: Boolean = false,

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
@@ -73,12 +73,12 @@ class FunctionWriter {
                 writer.emit(",$SPACE")
             }
 
-            if (functionSpec.requiredParameters.isNotEmpty()) {
-                functionSpec.requiredParameters.emitSpecialParameters(writer, emitAsRequired = true)
+            if (functionSpec.specialParameters.isNotEmpty()) {
+                functionSpec.specialParameters.emitSpecialParameters(writer, emitAsRequired = true)
             }
 
-            if (functionSpec.namedParameters.isNotEmpty()) {
-                functionSpec.namedParameters.emitSpecialParameters(writer, emitAsRequired = false)
+            if (functionSpec.defaultParameters.isNotEmpty()) {
+                functionSpec.defaultParameters.emitSpecialParameters(writer, emitAsRequired = false)
             }
 
             writer.emit(")")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
@@ -24,12 +24,13 @@ class ParameterWriter {
             it.write(codeWriter)
         }
 
+        if (spec.isRequired) {
+            codeWriter.emit("${DartModifier.REQUIRED.identifier}·")
+        }
+
         if (spec.type != null) {
             codeWriter.emitCode("%T", spec.type)
         } else {
-            if (spec.isRequired) {
-                codeWriter.emit("${DartModifier.REQUIRED.identifier}·")
-            }
             codeWriter.emit("this.")
         }
         codeWriter.emit(if (spec.isNullable) "?·" else if (spec.type != null) "·" else "")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -57,7 +57,7 @@ class FunctionSpec(
         }
 
         if (isGetter && asSetter) {
-            throw IllegalArgumentException("The function can't be a setter and a getter twice")
+            throw IllegalArgumentException("The function can't be a setter and a getter at the same time")
         }
 
         if (isLambda && body.isEmpty()) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -38,10 +38,6 @@ class ParameterSpec internal constructor(
      */
     init {
         require(name.trim().isNotEmpty()) { "The name of a parameter can't be empty" }
-
-        if (isNamed && !isRequired && !isNullable && (this.initializer == null || this.initializer.isEmpty())) {
-            throw IllegalArgumentException("A named parameter needs an initializer when it's not nullable")
-        }
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -37,7 +37,11 @@ class ParameterSpec internal constructor(
      * It ensures that the given name is not empty by trimming it and checking for non-empty content.
      */
     init {
-        check(name.trim().isNotEmpty()) { "The name of a parameter can't be empty" }
+        require(name.trim().isNotEmpty()) { "The name of a parameter can't be empty" }
+
+        if (isNamed && !isRequired && !isNullable && (this.initializer == null || this.initializer.isEmpty())) {
+            throw IllegalArgumentException("A named parameter needs an initializer when it's not nullable")
+        }
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -28,7 +28,7 @@ internal const val ROUND_OPEN = "("
 internal const val ROUND_CLOSE = ")"
 
 internal val ALLOWED_FUNCTION_MODIFIERS =
-    setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC, DartModifier.TYPEDEF)
+    setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC, DartModifier.TYPEDEF, DartModifier.ABSTRACT)
 internal val ALLOWED_PROPERTY_MODIFIERS =
     setOf(DartModifier.PRIVATE, DartModifier.FINAL, DartModifier.LATE, DartModifier.STATIC, DartModifier.CONST)
 internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.CONST)

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -34,12 +34,46 @@ class FunctionWriterTest {
                     .build()
             )
         )
+
+        @JvmStatic
+        private fun functionsWithSpecialParameters() = Stream.of(
+            Arguments.of(
+                "abstract int getIdRange(int maxValue, [int minValue = 0]);",
+                { FunctionSpec.builder("getIdRange")
+                    .returns(Int::class)
+                    .modifier { DartModifier.ABSTRACT }
+                    .parameters(
+                        ParameterSpec.builder("maxValue", Int::class).build(),
+                        ParameterSpec.builder("minValue", Int::class).initializer("%L", "0").named(true).build()
+                    )
+                    .build()
+                }
+            ),
+            Arguments.of(
+                "abstract int getIdRange(int maxValue, {required int minValue = 0});",
+                { FunctionSpec.builder("getIdRange")
+                    .returns(Int::class)
+                    .modifier { DartModifier.ABSTRACT }
+                    .parameters(
+                        ParameterSpec.builder("maxValue", Int::class).build(),
+                        ParameterSpec.builder("minValue", Int::class).initializer("%L", "0").required(true).build()
+                    )
+                    .build()
+                }
+            )
+        )
     }
 
     @ParameterizedTest
     @MethodSource("castFunctionWrite")
     fun `test function write with cast typeNames`(expected: String, functionSpec: FunctionSpec) {
         assertThat(functionSpec.toString()).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @MethodSource("functionsWithSpecialParameters")
+    fun `test function generation with special parameters`(expected: String, functionSpec: () -> FunctionSpec) {
+        assertThat(functionSpec().toString()).isEqualTo(expected)
     }
 
     @Test

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -44,19 +44,21 @@ class FunctionWriterTest {
                     .modifier { DartModifier.ABSTRACT }
                     .parameters(
                         ParameterSpec.builder("maxValue", Int::class).build(),
-                        ParameterSpec.builder("minValue", Int::class).initializer("%L", "0").named(true).build()
+                        ParameterSpec.builder("minValue", Int::class)
+                            .initializer("%L", "0")
+                            .build()
                     )
                     .build()
                 }
             ),
             Arguments.of(
-                "abstract int getIdRange(int maxValue, {required int minValue = 0});",
+                "abstract int getIdRange(int maxValue, {required int minValue});",
                 { FunctionSpec.builder("getIdRange")
                     .returns(Int::class)
                     .modifier { DartModifier.ABSTRACT }
                     .parameters(
                         ParameterSpec.builder("maxValue", Int::class).build(),
-                        ParameterSpec.builder("minValue", Int::class).initializer("%L", "0").required(true).build()
+                        ParameterSpec.builder("minValue", Int::class).required(true).build()
                     )
                     .build()
                 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -32,7 +32,7 @@ class FunctionSpecTest {
                 { FunctionSpec.builder("getName").modifier(DartModifier.ABSTRACT).addCode("%L", "value").build() }
             ),
             Arguments.of(
-                "The function can't be a setter and a getter twice",
+                "The function can't be a setter and a getter at the same time",
                 { FunctionSpec.builder("getName").setter(true).getter(true).build() }
             ),
             Arguments.of(

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -40,11 +40,11 @@ class FunctionSpecTest {
                 { FunctionSpec.builder("getName").lambda(true).build() }
             ),
             Arguments.of(
-                "A function only can have named or required parameters and not both of them",
+                "A function can only have required with named parameters but not with parameters that have a default value",
                 { FunctionSpec.builder("getName")
                     .parameters(
                         ParameterSpec.builder("test").named(true).build(),
-                        ParameterSpec.builder("value").required(true).build()
+                        ParameterSpec.builder("value").initializer("%C", "String").build()
                     )
                     .build()
                 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
@@ -3,9 +3,36 @@ package net.theevilreaper.dartpoet.parameter
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 import kotlin.test.assertContentEquals
 
 class ParameterSpecTest {
+
+    companion object {
+
+        @JvmStatic
+        private fun invalidParameterCreation() = Stream.of(
+            Arguments.of(
+                "The name of a parameter can't be empty",
+                { ParameterSpec.builder("").build() }
+            ),
+            Arguments.of(
+                "A named parameter needs an initializer when it's not nullable",
+                { ParameterSpec.builder("test", String::class).named(true).build() }
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidParameterCreation")
+    fun `test invalid parameter creation`(exceptionMessage: String, parameterSpec: () -> ParameterSpec) {
+        val exception = assertThrows<IllegalArgumentException> { parameterSpec() }
+        assertEquals(exceptionMessage, exception.message)
+    }
 
     @Test
     fun `test spec to builder conversation`() {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
@@ -20,10 +20,6 @@ class ParameterSpecTest {
                 "The name of a parameter can't be empty",
                 { ParameterSpec.builder("").build() }
             ),
-            Arguments.of(
-                "A named parameter needs an initializer when it's not nullable",
-                { ParameterSpec.builder("test", String::class).named(true).build() }
-            )
         )
     }
 


### PR DESCRIPTION
## Proposed changes

The programming language has parameters which can be `required` or `named`. Each variant of them requires a different generation logic. The issue #57 describes the wrong generation behaviour. So this pull request introduces a fix for this mentioned issue. (Closes #57)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...