### PR TITLE
Add generation of export directives

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
@@ -5,13 +5,10 @@ import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.DartFileWriter
+import net.theevilreaper.dartpoet.directive.*
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.util.*
-import net.theevilreaper.dartpoet.directive.DartDirective
-import net.theevilreaper.dartpoet.directive.LibraryDirective
-import net.theevilreaper.dartpoet.directive.PartDirective
-import net.theevilreaper.dartpoet.directive.RelativeDirective
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.util.DART_FILE_ENDING
 import net.theevilreaper.dartpoet.util.isDartConventionFileName
@@ -39,6 +36,7 @@ class DartFile internal constructor(
     internal val packageImports = DirectiveOrdering.sortDirectives<DartDirective>(DartDirective::class, directives) { it.contains("package:")}
     internal val partImports = DirectiveOrdering.sortDirectives<PartDirective>(PartDirective::class, directives)
     internal val libImport = DirectiveOrdering.sortDirectives<LibraryDirective>(LibraryDirective::class, directives)
+    internal val exportDirectives = DirectiveOrdering.sortDirectives<ExportDirective>(ExportDirective::class, directives)
     internal val relativeImports = DirectiveOrdering.sortDirectives<RelativeDirective>(RelativeDirective::class, directives)
     init {
         check(name.trim().isNotEmpty()) { "The name of a class can't be empty (ONLY SPACES ARE NOT ALLOWED" }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/DartFileWriter.kt
@@ -16,6 +16,7 @@ internal class DartFileWriter : Writeable<DartFile>, DocumentationAppender {
         emitDirectives(writer, spec.dartImports)
         emitDirectives(writer, spec.packageImports)
         emitDirectives(writer, spec.relativeImports)
+        emitDirectives(writer, spec.exportDirectives)
         emitDirectives(writer, spec.partImports)
 
         spec.constants.emitConstants(writer)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/ExportDirective.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/ExportDirective.kt
@@ -13,18 +13,41 @@ import net.theevilreaper.dartpoet.util.SEMICOLON
  * @author theEvilReaper
  */
 class ExportDirective(
-    private val path: String
+    private val path: String,
+    private val castType: CastType? = null,
+    private val importCast: String? = null,
 ): BaseDirective(path) {
+
+    private val export = "export"
+    private val invalidCastType = arrayOf(CastType.DEFERRED, CastType.AS)
+
+    init {
+        if (castType != null) {
+            if (castType in invalidCastType) {
+                throw IllegalStateException("The following cast types are not allowed for an export directive: [${invalidCastType.joinToString()}]")
+            }
+        }
+
+        if (importCast != null) {
+            check(importCast.trim().isNotEmpty()) { "The importCast can't be empty" }
+        }
+    }
 
     /**
      * Writes an [ExportDirective] with the right syntax to an [CodeWriter] instance.
      * @param writer the [CodeWriter] instance to append the directive
      */
     override fun write(writer: CodeWriter) {
-        writer.emit("export·")
-        writer.emit("'")
-        writer.emit(path.ensureDartFileEnding())
-        writer.emit("'")
-        writer.emit(SEMICOLON)
+        writer.emit("$export·'")
+        if (importCast == null && castType == null) {
+            writer.emit(path.ensureDartFileEnding())
+            writer.emit("'$SEMICOLON")
+        } else if (importCast != null && castType != null) {
+            writer.emit(path.ensureDartFileEnding())
+            writer.emit("' ${castType.identifier} $importCast")
+            writer.emit(SEMICOLON)
+        } else {
+            throw Error("Something went wrong during the ExportDirective write process")
+        }
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileImportTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileImportTest.kt
@@ -1,10 +1,13 @@
 package net.theevilreaper.dartpoet
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.*
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.buildCodeBlock
+import net.theevilreaper.dartpoet.directive.CastType
 import net.theevilreaper.dartpoet.directive.DartDirective
+import net.theevilreaper.dartpoet.directive.ExportDirective
+import net.theevilreaper.dartpoet.directive.PartDirective
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
@@ -46,7 +49,7 @@ class DartFileImportTest {
                     )
             )
             .build()
-        Truth.assertThat(dartFile.toString()).isEqualTo(
+        assertThat(dartFile.toString()).isEqualTo(
             """
             import 'dart:io';
             import 'dart:math';
@@ -65,5 +68,40 @@ class DartFileImportTest {
             
             """.trimIndent()
         )
+    }
+
+    @Test
+    fun `test directives with an export directive`() {
+        val classFile = DartFile.builder("House")
+            .directives(
+                DartDirective("dart:io"),
+                DartDirective("door"),
+                PartDirective("house_part.dart"),
+                ExportDirective("garden.dart", CastType.SHOW, "garden"),
+            )
+            .type(
+                ClassSpec.builder("House")
+                    .annotation(
+                        AnnotationSpec.builder("immutable")
+                            .build()
+                    )
+                    .endWithNewLine(true)
+                    .build()
+            )
+            .build()
+        assertThat(classFile.toString()).isEqualTo(
+            """
+            import 'dart:io';
+            
+            import 'package:door.dart';
+            
+            export 'garden.dart' show garden;
+            
+            part 'house_part.dart';
+            
+            @immutable
+            class House {}
+            
+            """.trimIndent())
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/directive/ExportDirectiveTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/directive/ExportDirectiveTest.kt
@@ -1,0 +1,52 @@
+package net.theevilreaper.dartpoet.directive
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class ExportDirectiveTest {
+
+    companion object {
+
+        @JvmStatic
+        private fun invalidExportDirectives(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                { ExportDirective("") },
+                "The path of an directive can't be empty"
+            ),
+            Arguments.of(
+                { ExportDirective("dart:math", CastType.DEFERRED, "math") },
+                "The following cast types are not allowed for an export directive: [DEFERRED, AS]"
+            ),
+            Arguments.of(
+                { ExportDirective("dart:math", CastType.AS, "math") },
+                "The following cast types are not allowed for an export directive: [DEFERRED, AS]"
+            )
+        )
+
+        @JvmStatic
+        private fun exportDirectives(): Stream<Arguments> = Stream.of(
+            Arguments.of(ExportDirective("test.dart"), "export 'test.dart';"),
+            Arguments.of(ExportDirective("new_lib"), "export 'new_lib.dart';"),
+            Arguments.of(ExportDirective("new_lib", CastType.SHOW, "lib"), "export 'new_lib.dart' show lib;"),
+            Arguments.of(ExportDirective("new_lib", CastType.HIDE, "lib"), "export 'new_lib.dart' hide lib;")
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidExportDirectives")
+    fun `test invalid export directives`(current: () -> ExportDirective, expected: String) {
+        val exception = assertThrows<IllegalStateException> { current() }
+        assertEquals(IllegalStateException::class.java, exception.javaClass)
+        assertEquals(expected, exception.message)
+    }
+
+    @ParameterizedTest
+    @MethodSource("exportDirectives")
+    fun `test export directives`(current: ExportDirective, expected: String) {
+        assertEquals(expected, current.asString())
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -5,7 +5,6 @@ import net.theevilreaper.dartpoet.type.asTypeName
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 


### PR DESCRIPTION
## Proposed changes

Dart also includes an 'export' keyword that enables the definition of export directives. The current implementation lacks this feature. This pull request implements the generation of it.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...