### PR TITLE
Revise parameter generation

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriter.kt
@@ -213,7 +213,7 @@ class CodeWriter constructor(
         for (line in s.split('\n')) {
             // Emit a newline character. Make sure blank lines in KDoc & comments look good.
             if (!first) {
-                if ( comment && trailingNewline) {
+                if (comment && trailingNewline) {
                     emitIndentation()
                     out.appendNonWrapping(DOCUMENTATION_CHAR)
                 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
@@ -110,13 +110,9 @@ internal fun Set<ConstructorSpec>.emitConstructors(
 internal fun List<ParameterSpec>.emitParameters(
     codeWriter: CodeWriter,
     forceNewLines: Boolean = false,
-    emitBrackets: Boolean = true,
     emitSpace: Boolean = true,
     emitBlock: (ParameterSpec) -> Unit = { it.write(codeWriter) }
 ) = with(codeWriter) {
-    if (emitBrackets) {
-        emit("(")
-    }
     if (isNotEmpty()) {
         val emitComma = size > 1
         forEachIndexed { index, parameter ->
@@ -134,9 +130,6 @@ internal fun List<ParameterSpec>.emitParameters(
                 }
             }
         }
-    }
-    if (emitBrackets) {
-        emit(")")
     }
 }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/InitializerAppender.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/InitializerAppender.kt
@@ -1,11 +1,15 @@
 package net.theevilreaper.dartpoet.code
 
 /**
+ * An internal interface for appending initializer blocks to a [CodeWriter] for a given type [T].
+ * Initializer blocks contain data that should be emitted into a [CodeWriter] instance.
+ * This interface provides methods to write initializer blocks for a [CodeBlock] or an object of type [T].
  *
+ * @param T the type of object for which initializer blocks are appended.
  * @author theEvilReaper
  * @since 1.0.0
  */
-internal interface InitializerAppender {
+internal interface InitializerAppender<T: Any> {
 
     /**
      * When a spec object contains data for an initializer block it should be emitted into a writer instance.
@@ -16,5 +20,16 @@ internal interface InitializerAppender {
         if (initBlock.isEmpty()) return
         writer.emit("·=·")
         writer.emitCode(initBlock, isConstantContext)
+    }
+
+    /**
+     * When a spec object contains data for an initializer block it should be emitted into a writer instance.
+     * @param spec the spec object which contains the initializer block
+     * @param writer the [CodeWriter] instance to write the code
+     * @param isConstantContext a flag indicating whether the context is constant (default is true).
+     * @throws UnsupportedOperationException if this method is called and not implemented.
+     */
+    fun writeInitBlock(spec: T, writer: CodeWriter, isConstantContext: Boolean = true) {
+        throw UnsupportedOperationException("Not implemented yet")
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ConstantPropertyWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ConstantPropertyWriter.kt
@@ -8,7 +8,7 @@ import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.util.SEMICOLON
 import net.theevilreaper.dartpoet.util.SPACE
 
-internal class ConstantPropertyWriter : Writeable<ConstantPropertySpec>, InitializerAppender, VariableAppender {
+internal class ConstantPropertyWriter : Writeable<ConstantPropertySpec>, InitializerAppender<PropertyWriter>, VariableAppender {
 
     override fun write(spec: ConstantPropertySpec, writer: CodeWriter) {
         val modifiersAsString = spec.modifiers.joinToString(separator = SPACE, postfix = SPACE) { it.identifier }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriter.kt
@@ -36,7 +36,7 @@ internal class ConstructorWriter : Writeable<ConstructorSpec>, DocumentationAppe
 
         writer.emit("(")
 
-        spec.parameters.emitParameters(writer, emitBrackets = false)
+        spec.parameters.emitParameters(writer)
 
         if (spec.hasNamedParameters) {
             if (spec.parameters.isNotEmpty()) {
@@ -46,7 +46,7 @@ internal class ConstructorWriter : Writeable<ConstructorSpec>, DocumentationAppe
             writer.emit(NEW_LINE)
             writer.indent()
 
-            spec.requiredAndNamedParameters.emitParameters(writer, emitBrackets = false, emitSpace = false, forceNewLines = true) {
+            spec.requiredAndNamedParameters.emitParameters(writer, emitSpace = false, forceNewLines = true) {
                 it.write(writer)
             }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
@@ -97,7 +97,8 @@ internal class FunctionWriter : Writeable<FunctionSpec> {
     }
 
     private fun writeParameters(spec: FunctionSpec, codeWriter: CodeWriter) {
-        if (!spec.hasParameters && spec.isTypeDef) {
+        if (!spec.hasParameters) {
+            codeWriter.emit("()")
             return
         }
         codeWriter.emit("(")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
@@ -127,39 +127,21 @@ internal class FunctionWriter : Writeable<FunctionSpec> {
         val namedRequired = spec.namedParameter.filter { it.isRequired && !it.hasInitializer }.toImmutableList()
 
         writeParameters(namedRequired, spec.normalParameter.isNotEmpty(), codeWriter)
-        /*if (namedRequired.isNotEmpty()) {
-            namedRequired.emitParameters(codeWriter, forceNewLines = false)
-
-            if (spec.requiredParameter.isNotEmpty()) {
-                codeWriter.emit(", ")
-            }
-        }*/
-
         writeParameters(spec.requiredParameter, namedRequired.isNotEmpty(), codeWriter)
-       // spec.requiredParameter.emitParameters(codeWriter, forceNewLines = false)
 
         val test =
             spec.namedParameter.minus(namedRequired).filter { it.isNullable || it.hasInitializer }.toImmutableList()
 
         writeParameters(test, spec.requiredParameter.isNotEmpty() || namedRequired.isNotEmpty(), codeWriter)
-        /*if (test.isNotEmpty()) {
-            codeWriter.emit(", ")
-            test.emitParameters(codeWriter, forceNewLines = false)
-        }*/
 
         codeWriter.emit("$CURLY_CLOSE")
     }
 
-    private fun writeTypeDef(spec: FunctionSpec, codeWriter: CodeWriter) {
-        codeWriter.emit("${TYPEDEF.identifier}·")
-        codeWriter.emit("${spec.name}·")
-        codeWriter.emit("=·")
-        codeWriter.emit("${spec.returnType}")
-        writeParameters(spec, codeWriter)
-        codeWriter.emit(SEMICOLON)
-    }
-
-    private fun writeParameters(parameters: List<ParameterSpec>, emitSpaceComma: Boolean = false, codeWriter: CodeWriter) {
+    private fun writeParameters(
+        parameters: List<ParameterSpec>,
+        emitSpaceComma: Boolean = false,
+        codeWriter: CodeWriter
+    ) {
         if (parameters.isEmpty()) return
         if (emitSpaceComma) {
             codeWriter.emit(", ")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
@@ -21,7 +21,7 @@ internal class ParameterWriter : Writeable<ParameterSpec>, InitializerAppender<P
     override fun write(spec: ParameterSpec, writer: CodeWriter) {
         spec.annotations.emitAnnotations(writer, endWithNewLine = false)
 
-        if (spec.isRequired) {
+        if (spec.isRequired && (!spec.isNamed || !spec.hasInitializer)) {
             writer.emit("${DartModifier.REQUIRED.identifier}·")
         }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
@@ -13,7 +13,7 @@ import net.theevilreaper.dartpoet.util.SPACE
  * @author theEvilReaper
  * @since 1.0.0
  */
-internal class PropertyWriter : Writeable<PropertySpec>, VariableAppender, DocumentationAppender, InitializerAppender {
+internal class PropertyWriter : Writeable<PropertySpec>, VariableAppender, DocumentationAppender, InitializerAppender<PropertySpec> {
 
     /**
      * Writes the given [PropertySpec] into the [CodeWriter].

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriter.kt
@@ -23,7 +23,7 @@ class TypeDefWriter : Writeable<TypeDefSpec> {
 
         if (spec.hasParameters) {
             writer.emit("(")
-            spec.parameters.emitParameters(writer, forceNewLines = false, emitBrackets = false, emitSpace = spec.parameters.size > 1)
+            spec.parameters.emitParameters(writer, forceNewLines = false,emitSpace = spec.parameters.size > 1)
             writer.emit(")")
         }
         writer.emit(SEMICOLON)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriter.kt
@@ -5,9 +5,12 @@ import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.Writeable
 import net.theevilreaper.dartpoet.code.emitParameters
 import net.theevilreaper.dartpoet.function.typedef.TypeDefSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.util.SEMICOLON
+import net.theevilreaper.dartpoet.util.toImmutableList
 
 class TypeDefWriter : Writeable<TypeDefSpec> {
+
     override fun write(spec: TypeDefSpec, writer: CodeWriter) {
         writer.emit("${DartModifier.TYPEDEF.identifier}·${spec.typeDefName}")
         if (spec.typeCasts.isNotEmpty()) {
@@ -21,11 +24,53 @@ class TypeDefWriter : Writeable<TypeDefSpec> {
             writer.emitCode("·%L", spec.name)
         }
 
-        if (spec.hasParameters) {
-            writer.emit("(")
-            spec.parameters.emitParameters(writer, forceNewLines = false,emitSpace = spec.parameters.size > 1)
-            writer.emit(")")
-        }
+        emitParameters(spec, writer)
         writer.emit(SEMICOLON)
+    }
+
+    private fun emitParameters(spec: TypeDefSpec, codeWriter: CodeWriter) {
+        if (spec.hasParameters) {
+            codeWriter.emit("(")
+            callParameterWrite(codeWriter, spec.normalParameter) { it.isNotEmpty() }
+            if (spec.hasAdditionalParameters) {
+                if (spec.hasParameters) {
+                    codeWriter.emit(",")
+                }
+                codeWriter.emit("·{")
+                val namedRequired = spec.namedParameter.filter { it.isRequired && !it.hasInitializer }.toImmutableList()
+
+                callParameterWrite(codeWriter, namedRequired) { it.isNotEmpty() }
+                callParameterWrite(codeWriter, spec.requiredParameter) { it.isNotEmpty() }
+
+                if (namedRequired.isNotEmpty()) {
+                    codeWriter.emitCode(",·")
+                }
+
+                val test =
+                    spec.namedParameter.minus(namedRequired).filter { it.isNullable || it.hasInitializer }.toImmutableList()
+                callParameterWrite(codeWriter, test) { it.isNotEmpty() }
+                codeWriter.emit("}")
+            }
+
+            if (spec.parametersWithDefaults.isNotEmpty()) {
+                if (spec.hasParameters) {
+                    codeWriter.emit(", ")
+                }
+                codeWriter.emit("[")
+                callParameterWrite(codeWriter, spec.parametersWithDefaults) { it.isNotEmpty() }
+                codeWriter.emit("]")
+            }
+
+            codeWriter.emit(")")
+        }
+    }
+
+    private inline fun callParameterWrite(
+        writer: CodeWriter,
+        parameters: List<ParameterSpec>,
+        crossinline predicate: (List<ParameterSpec>) -> Boolean,
+    ) {
+        if (!predicate.invoke(parameters)) return
+        parameters.emitParameters(writer, forceNewLines = false, emitSpace = parameters.size > 1)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -32,14 +32,16 @@ class FunctionSpec(
     internal val modifiers: Set<DartModifier> = builder.specData.modifiers.also {
         hasAllowedModifiers(it, ALLOWED_FUNCTION_MODIFIERS, "function")
     }.filter { it != DartModifier.PRIVATE && it != DartModifier.PUBLIC }.toImmutableSet()
-    internal val parametersWithDefaults = ParameterFilter.filterParameter(parameters) { !it.isRequired && it.hasInitializer }
-    internal val requiredParameter = ParameterFilter.filterParameter(parameters) { it.isRequired && !it.isNamed && !it.hasInitializer }
+    internal val parametersWithDefaults =
+        ParameterFilter.filterParameter(parameters) { !it.isRequired && it.hasInitializer }
+    internal val requiredParameter =
+        ParameterFilter.filterParameter(parameters) { it.isRequired && !it.isNamed && !it.hasInitializer }
     internal val namedParameter = ParameterFilter.filterParameter(parameters) { it.isNamed }
-    internal val normalParameter = parameters.minus(parametersWithDefaults).minus(requiredParameter).minus(namedParameter).toImmutableList()
-    internal val hasParameters = normalParameter.isNotEmpty()
+    internal val normalParameter =
+        parameters.minus(parametersWithDefaults).minus(requiredParameter).minus(namedParameter).toImmutableList()
+    internal val hasParameters = parameters.isNotEmpty()
     internal val hasAdditionalParameters = requiredParameter.isNotEmpty() || namedParameter.isNotEmpty()
 
-    internal val isTypeDef = builder.typedef
     internal val isPrivate = builder.specData.modifiers.remove(DartModifier.PRIVATE)
     internal val typeCast = builder.typeCast
     internal val asSetter = builder.setter
@@ -47,6 +49,7 @@ class FunctionSpec(
     internal val isLambda = builder.lambda
     internal val docs = builder.docs
     internal val hasDocs = builder.docs.isNotEmpty()
+
     init {
         require(name.trim().isNotEmpty()) { "The name of a function can't be empty" }
         require(body.isEmpty() || !modifiers.contains(DartModifier.ABSTRACT)) { "An abstract method can't have a body" }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -23,7 +23,6 @@ import net.theevilreaper.dartpoet.util.toImmutableSet
 class FunctionSpec(
     builder: FunctionBuilder
 ) {
-
     internal val name = builder.name
     internal val returnType: TypeName? = builder.returnType
     internal val body: CodeBlock = builder.body.build()
@@ -34,10 +33,11 @@ class FunctionSpec(
         hasAllowedModifiers(it, ALLOWED_FUNCTION_MODIFIERS, "function")
     }.filter { it != DartModifier.PRIVATE && it != DartModifier.PUBLIC }.toImmutableSet()
     internal val parametersWithDefaults = ParameterFilter.filterParameter(parameters) { !it.isRequired && it.hasInitializer }
-    internal val requiredParameter = ParameterFilter.filterParameter(parameters) { it.isRequired }
-    internal val normalParameter = parameters.minus(parametersWithDefaults).minus(requiredParameter).toImmutableList()
-    internal val hasSpecialParameters = requiredParameter.isNotEmpty() || parametersWithDefaults.isNotEmpty()
+    internal val requiredParameter = ParameterFilter.filterParameter(parameters) { it.isRequired && !it.isNamed && !it.hasInitializer }
+    internal val namedParameter = ParameterFilter.filterParameter(parameters) { it.isNamed }
+    internal val normalParameter = parameters.minus(parametersWithDefaults).minus(requiredParameter).minus(namedParameter).toImmutableList()
     internal val hasParameters = normalParameter.isNotEmpty()
+    internal val hasAdditionalParameters = requiredParameter.isNotEmpty() || namedParameter.isNotEmpty()
 
     internal val isPrivate = builder.specData.modifiers.contains(DartModifier.PRIVATE)
     internal val isTypeDef = builder.typedef
@@ -48,7 +48,6 @@ class FunctionSpec(
     internal val docs = builder.docs
     internal val hasDocs = builder.docs.isNotEmpty()
     init {
-        //check(!isTypeDef && annotation.isNotEmpty()) { "A typedef can't have annotations" }
         require(name.trim().isNotEmpty()) { "The name of a function can't be empty" }
         require(body.isEmpty() || !modifiers.contains(DartModifier.ABSTRACT)) { "An abstract method can't have a body" }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -27,12 +27,18 @@ class FunctionSpec(
     internal val name = builder.name
     internal val returnType: TypeName? = builder.returnType
     internal val body: CodeBlock = builder.body.build()
-    internal val parameters: List<ParameterSpec> = builder.parameters.toImmutableList()
+    private val parameters: List<ParameterSpec> = builder.parameters.toImmutableList()
     internal val isAsync: Boolean = builder.async
     internal val annotation: Set<AnnotationSpec> = builder.specData.annotations.toImmutableSet()
-    internal var modifiers: Set<DartModifier> = builder.specData.modifiers.also {
+    internal val modifiers: Set<DartModifier> = builder.specData.modifiers.also {
         hasAllowedModifiers(it, ALLOWED_FUNCTION_MODIFIERS, "function")
     }.filter { it != DartModifier.PRIVATE && it != DartModifier.PUBLIC }.toImmutableSet()
+    internal val parametersWithDefaults = ParameterFilter.filterParameter(parameters) { !it.isRequired && it.hasInitializer }
+    internal val requiredParameter = ParameterFilter.filterParameter(parameters) { it.isRequired }
+    internal val normalParameter = parameters.minus(parametersWithDefaults).minus(requiredParameter).toImmutableList()
+    internal val hasSpecialParameters = requiredParameter.isNotEmpty() || parametersWithDefaults.isNotEmpty()
+    internal val hasParameters = normalParameter.isNotEmpty()
+
     internal val isPrivate = builder.specData.modifiers.contains(DartModifier.PRIVATE)
     internal val isTypeDef = builder.typedef
     internal val typeCast = builder.typeCast
@@ -41,13 +47,6 @@ class FunctionSpec(
     internal val isLambda = builder.lambda
     internal val docs = builder.docs
     internal val hasDocs = builder.docs.isNotEmpty()
-
-    private val namedParameters: Set<ParameterSpec> = if (parameters.isEmpty()) {
-        setOf()
-    } else {
-        parameters.filter { it.isNamed }.toSet()
-    }
-
     init {
         //check(!isTypeDef && annotation.isNotEmpty()) { "A typedef can't have annotations" }
         require(name.trim().isNotEmpty()) { "The name of a function can't be empty" }
@@ -59,6 +58,10 @@ class FunctionSpec(
 
         if (isLambda && body.isEmpty()) {
             throw IllegalArgumentException("Lambda can only be used with a body")
+        }
+
+        if (requiredParameter.isNotEmpty() && parametersWithDefaults.isNotEmpty()) {
+            throw IllegalArgumentException("A function can't have required and optional parameters")
         }
 
         //require (isFactory && returnType == null && !isNullable) { "A void function can't be nullable" }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/TypeDefSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/TypeDefSpec.kt
@@ -7,6 +7,7 @@ import net.theevilreaper.dartpoet.code.writer.TypeDefWriter
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.type.asTypeName
+import net.theevilreaper.dartpoet.util.ParameterFilter
 import net.theevilreaper.dartpoet.util.toImmutableList
 import kotlin.reflect.KClass
 
@@ -23,7 +24,15 @@ class TypeDefSpec(
     internal val typeCasts = builder.typeCasts
     internal val returnType = builder.returnType ?: Void::class.asTypeName()
     internal val parameters = builder.parameters.toImmutableList()
-    internal val hasParameters = parameters.isNotEmpty()
+    internal val parametersWithDefaults =
+        ParameterFilter.filterParameter(parameters) { !it.isRequired && it.hasInitializer }
+    internal val requiredParameter =
+        ParameterFilter.filterParameter(parameters) { it.isRequired && !it.isNamed && !it.hasInitializer }
+    internal val namedParameter = ParameterFilter.filterParameter(parameters) { it.isNamed }
+    internal val normalParameter =
+        parameters.minus(parametersWithDefaults).minus(requiredParameter).minus(namedParameter).toImmutableList()
+    internal val hasAdditionalParameters = requiredParameter.isNotEmpty() || namedParameter.isNotEmpty()
+    internal val hasParameters = normalParameter.isNotEmpty()
 
     /**
      * Performs some checks to avoid invalid data.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterBuilder.kt
@@ -26,7 +26,6 @@ class ParameterBuilder internal constructor(
 ) : SpecMethods<ParameterBuilder> {
     internal val specData: SpecData = SpecData()
     internal var named: Boolean = false
-    internal var required: Boolean = false
     internal var nullable: Boolean = false
     internal var initializer: CodeBlock? = null
 
@@ -42,12 +41,21 @@ class ParameterBuilder internal constructor(
         this.named = named
     }
 
+    /**
+     * Indicates whether the parameter is nullable or not.
+     * @param nullable true if the parameter is nullable, false otherwise
+     * @return the current [ParameterBuilder] instance
+     */
     fun nullable(nullable: Boolean) = apply {
         this.nullable = nullable
     }
 
-    fun required(required: Boolean) = apply {
-        this.required = required
+    /**
+     * Indicates that the parameter is required.
+     * @return the current [ParameterBuilder] instance
+     */
+    fun required() = apply {
+        this.modifiers(DartModifier.REQUIRED)
     }
 
     override fun annotation(annotation: () -> AnnotationSpec) = apply {
@@ -71,7 +79,7 @@ class ParameterBuilder internal constructor(
     }
 
     override fun modifiers(vararg modifiers: DartModifier) = apply {
-        TODO("Not yet implemented")
+        this.specData.modifiers += modifiers
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.dartpoet.parameter
 
+import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.ParameterWriter
@@ -28,9 +29,10 @@ class ParameterSpec internal constructor(
     internal val type = builder.typeName
     internal val isNamed = builder.named
     internal val isNullable = builder.nullable
-    internal val isRequired = builder.required
+    internal val isRequired = builder.specData.modifiers.contains(DartModifier.REQUIRED)
     internal val initializer = builder.initializer
     internal val annotations = builder.specData.annotations.toImmutableSet()
+    internal val hasInitializer = initializer != null && initializer.isNotEmpty()
 
     /**
      * This init block is responsible for performing initial checks on the name parameter.
@@ -64,8 +66,10 @@ class ParameterSpec internal constructor(
         val builder = ParameterBuilder(this.name, this.type)
         builder.named = isNamed
         builder.nullable = isNullable
-        builder.required = isRequired
         builder.annotations(*this.annotations.toTypedArray())
+        if (isRequired) {
+            builder.modifiers(DartModifier.REQUIRED)
+        }
         builder.initializer = initializer
         return builder
     }
@@ -75,8 +79,8 @@ class ParameterSpec internal constructor(
         /**
          * Creates a new instance of [ParameterBuilder] with the specified name and type.
          *
-         * @param name The name for the parameter. Should adhere to naming conventions
-         * @param type The type for the parameter, represented as a [TypeName]
+         * @param name the name for the parameter. Should adhere to naming conventions
+         * @param type the type for the parameter, represented as a [TypeName]
          * @return A new [ParameterBuilder] instance initialized with the provided name and type
          */
         @JvmStatic
@@ -86,7 +90,7 @@ class ParameterSpec internal constructor(
          * Creates a new instance of [ParameterBuilder] with the specified name and type.
          *
          * @param name The name for the parameter. Should adhere to naming conventions
-         * @param type The type for the parameter, represented as a [KClass]
+         * @param type the type for the parameter, represented as a [KClass]
          * @return A new [ParameterBuilder] instance initialized with the provided name and type
          */
         @JvmStatic
@@ -95,8 +99,8 @@ class ParameterSpec internal constructor(
         /**
          * Creates a new instance of [ParameterBuilder] with the specified name and type.
          *
-         * @param name The name for the parameter. Should adhere to naming conventions
-         * @param type The type for the parameter, represented as a [ClassName]
+         * @param name the name for the parameter. Should adhere to naming conventions
+         * @param className the type for the parameter, represented as a [ClassName]
          * @return A new [ParameterBuilder] instance initialized with the provided name and type
          */
         @JvmStatic
@@ -105,7 +109,7 @@ class ParameterSpec internal constructor(
         /**
          * Creates a new instance of [ParameterBuilder] with the specified name and type.
          *
-         * @param name The name for the parameter. Should adhere to naming conventions
+         * @param name the name for the parameter. Should adhere to naming conventions
          * @return A new [ParameterBuilder] instance initialized with the provided name and type
          */
         @JvmStatic

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -27,7 +27,7 @@ internal const val ROUND_OPEN = "("
 internal const val ROUND_CLOSE = ")"
 
 internal val ALLOWED_FUNCTION_MODIFIERS =
-    setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC, DartModifier.TYPEDEF)
+    setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC, DartModifier.TYPEDEF, DartModifier.ABSTRACT)
 internal val ALLOWED_PROPERTY_MODIFIERS =
     setOf(DartModifier.PRIVATE, DartModifier.FINAL, DartModifier.LATE, DartModifier.STATIC, DartModifier.CONST)
 internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.CONST)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -26,7 +26,7 @@ internal const val CURLY_CLOSE = '}'
 internal const val ROUND_OPEN = "("
 internal const val ROUND_CLOSE = ")"
 
-internal val ALLOWED_FUNCTION_MODIFIERS = setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC)
+internal val ALLOWED_FUNCTION_MODIFIERS = setOf(DartModifier.PUBLIC, DartModifier.PRIVATE, DartModifier.STATIC, DartModifier.ABSTRACT)
 internal val ALLOWED_PROPERTY_MODIFIERS =
     setOf(DartModifier.PRIVATE, DartModifier.FINAL, DartModifier.LATE, DartModifier.STATIC, DartModifier.CONST)
 internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.CONST)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/ParameterFilter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/ParameterFilter.kt
@@ -1,0 +1,23 @@
+package net.theevilreaper.dartpoet.util
+
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+
+/**
+ *  Utility class for filtering [ParameterSpec] lists.
+ *  @since 1.0.0
+ *  @version 1.0.0
+ *  @author theEvilReaper
+ */
+object ParameterFilter {
+
+    /**
+     * Filters the given [ParameterSpec] list by the given predicate.
+     * @param parameters the list of [ParameterSpec] to filter
+     * @param predicate the predicate to filter the list
+     * @return the filtered list
+     */
+    internal inline fun filterParameter(parameters: List<ParameterSpec>, crossinline predicate: (ParameterSpec) -> Boolean): List<ParameterSpec> {
+        if (parameters.isEmpty()) return emptyList()
+        return parameters.filter(predicate).toImmutableList()
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -196,7 +196,7 @@ class DartFileTest {
               final String name;
               final String route;
             
-              const NavigationEntry(this.name, this.route);
+              const NavigationEntry(name, route);
             
             }
             """.trimIndent()
@@ -419,7 +419,7 @@ class DartFileTest {
               String name;
             
               /// Good comment
-              TestModel(this.name);
+              TestModel(name);
             
               /// Returns the given name from the object
               String getName() {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
@@ -84,9 +84,9 @@ class ConstructorWriterTest {
     fun `test constructor with required and named parameters`() {
         val constructor = ConstructorSpec.builder("Car")
             .parameters(
-                ParameterSpec.builder("maker").required(true).build(),
+                ParameterSpec.builder("maker").required().build(),
                 ParameterSpec.builder("model").named(true).build(),
-                ParameterSpec.builder("yearMade").required(true).build(),
+                ParameterSpec.builder("yearMade").required().build(),
             )
             .build()
         assertThat(constructor.toString()).isEqualTo(
@@ -104,9 +104,9 @@ class ConstructorWriterTest {
     fun `test constructor with named and variable with initializer`() {
         val constructor = ConstructorSpec.builder("Item")
             .parameters(
-                ParameterSpec.builder("name").required(true).build(),
+                ParameterSpec.builder("name").required().build(),
                 ParameterSpec.builder("id").initializer("%L", 10L).build(),
-                ParameterSpec.builder("amount").required(true).build()
+                ParameterSpec.builder("amount").required().build()
             )
             .build()
         assertThat(constructor.toString()).isEqualTo(

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
@@ -21,7 +21,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Car(this.maker, this.model, this.yearMade, this.hasABS);
+            Car(maker, model, yearMade, hasABS);
             """.trimIndent()
         )
     }
@@ -37,7 +37,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Car.withoutABS(this.maker, this.model, this.yearMade);
+            Car.withoutABS(maker, model, yearMade);
             """.trimIndent()
         )
     }
@@ -58,7 +58,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Car.withoutABS(this.maker, this.model, this.yearMade): hasABS = false;
+            Car.withoutABS(maker, model, yearMade): hasABS = false;
             """.trimIndent()
         )
     }
@@ -75,7 +75,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            const Car(this.maker, this.model, this.yearMade);
+            const Car(maker, model, yearMade);
             """.trimIndent()
         )
     }
@@ -92,9 +92,9 @@ class ConstructorWriterTest {
         assertThat(constructor.toString()).isEqualTo(
             """
             Car({
-              required this.maker,
-              this.model,
-              required this.yearMade
+              required maker,
+              model,
+              required yearMade
             });
             """.trimIndent()
         )
@@ -111,10 +111,10 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Item(this.id = 10,
+            Item(id = 10,
             {
-              required this.name,
-              required this.amount
+              required name,
+              required amount
             });
             """.trimIndent()
         )
@@ -130,7 +130,7 @@ class ConstructorWriterTest {
         assertThat(constructor.toString()).isEqualTo(
             """
             /// Creates a new item object
-            Item(this.name);
+            Item(name);
             """.trimIndent()
         )
     }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -227,4 +227,29 @@ class FunctionWriterTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `test function write with named and required parameters`() {
+        val functionSpec = FunctionSpec.builder("testMethod")
+            .modifiers(DartModifier.ABSTRACT)
+            .parameter {
+                ParameterSpec.builder("a", String::class).named(true).nullable(true).build()
+            }
+            .parameter {
+                ParameterSpec.builder("b", String::class).named(true).required().build()
+            }
+            .parameter(
+                ParameterSpec.builder("c", Int::class)
+                    .named(true)
+                    .required()
+                    .initializer("%L", "10")
+                    .build()
+            )
+            .build()
+        assertThat(functionSpec.toString()).isEqualTo(
+            """
+           abstract void testMethod({required String b, String? a, int c = 10});
+            """.trimIndent()
+        )
+    }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriterTest.kt
@@ -2,25 +2,55 @@ package net.theevilreaper.dartpoet.code.writer
 
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 class ParameterWriterTest {
 
-    @Test
-    fun `write int parameter`() {
-        val param = ParameterSpec.builder("age", Int::class).build()
-        assertThat(param.toString()).isEqualTo("int age")
+    companion object {
+
+        @JvmStatic
+        private fun parameterTests(): Stream<Arguments> = Stream.of(
+            Arguments.of(ParameterSpec.builder("age", Int::class).build(), "int age"),
+            Arguments.of(ParameterSpec.builder("age", Int::class).initializer("%L", "10").build(), "int age = 10"),
+            Arguments.of(ParameterSpec.builder("test", String::class).nullable(true).build(), "String? test"),
+            Arguments.of(
+                ParameterSpec.builder("list", List::class.parameterizedBy(Int::class)).build(),
+                "List<int> list"
+            ),
+            Arguments.of(
+                ParameterSpec.builder("list", List::class.parameterizedBy(Int::class)).initializer("%L", "[]").build(),
+                "List<int> list = []"
+            ),
+            Arguments.of(
+                ParameterSpec.builder("map", Map::class.parameterizedBy(String::class, Int::class)).build(),
+                "Map<String, int> map"
+            ),
+            Arguments.of(
+                ParameterSpec.builder("map", Map::class.parameterizedBy(String::class, Int::class))
+                    .initializer("%L", "{}").build(),
+                "Map<String, int> map = {}"
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameterTests")
+    fun `test parameter write`(parameterSpec: ParameterSpec, expected: String) {
+        assertThat(parameterSpec.toString()).isEqualTo(expected)
     }
 
     @Test
-    fun `write int parameter with initializer`() {
-        val param = ParameterSpec.builder("age", Int::class).initializer("%L", "10").build()
-        assertThat(param.toString()).isEqualTo("int age = 10")
-    }
-
-    @Test
-    fun `write nullable parameter`() {
-        val param = ParameterSpec.builder("test", String::class).nullable(true).build()
-        assertThat(param.toString()).isEqualTo("String? test")
+    fun `test invalid parameter definition`() {
+        assertThrows(
+            IllegalStateException::class.java,
+            { ParameterSpec.builder("").build() },
+            "The name of a parameter can't be empty"
+        )
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
@@ -73,6 +73,72 @@ class TypeDefWriterTest {
                 "typedef Compare<E, T> = int Function(E a, E b);"
             )
         )
+
+        @JvmStatic
+        private fun differentParameterTypes(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                TypeDefSpec.builder("ValueUpdate", genericClassName)
+                    .name("Function")
+                    .returns(genericClassName)
+                    .parameters(
+                        ParameterSpec.builder("value", String::class)
+                            .build(),
+                        ParameterSpec.builder("data", genericClassName)
+                            .nullable(true)
+                            .initializer("%L", "null")
+                            .build()
+                    )
+                    .build(),
+                "typedef ValueUpdate<E> = E Function(String value, [E? data = null]);"
+            ),
+            Arguments.of(
+                TypeDefSpec.builder("ValueUpdate", genericClassName)
+                    .name("Function")
+                    .returns(genericClassName)
+                    .parameters(
+                        ParameterSpec.builder("map", Map::class.parameterizedBy(String::class, Int::class))
+                            .build(),
+                        ParameterSpec.builder("data", genericClassName)
+                            .nullable(true)
+                            .initializer("%L", "null")
+                            .build()
+                    )
+                    .build(),
+                "typedef ValueUpdate<E> = E Function(Map<String, int> map, [E? data = null]);"
+            ),
+            Arguments.of(
+                TypeDefSpec.builder("ValueUpdate", genericClassName)
+                    .name("Function")
+                    .returns(genericClassName)
+                    .parameters(
+                        ParameterSpec.builder("list", List::class.parameterizedBy(String::class))
+                            .build(),
+                        ParameterSpec.builder("data", genericClassName)
+                            .required()
+                            .build(),
+                    )
+                    .build(),
+                "typedef ValueUpdate<E> = E Function(List<String> list, {required E data});"
+            ),
+            Arguments.of(
+                TypeDefSpec.builder("ValueUpdate", genericClassName)
+                    .name("Function")
+                    .returns(genericClassName)
+                    .parameters(
+                        ParameterSpec.builder("data", genericClassName)
+                            .build(),
+                        ParameterSpec.builder("a", String::class).named(true).nullable(true).build(),
+                        ParameterSpec.builder("b", String::class).named(true).required().build(),
+                        ParameterSpec.builder("c", Int::class)
+                            .named(true)
+                            .required()
+                            .initializer("%L", "10")
+                            .build()
+                    )
+                    .build(),
+                "typedef ValueUpdate<E> = E Function(E data, {required String b, String? a, int c = 10});"
+            )
+        )
     }
 
     @ParameterizedTest
@@ -84,6 +150,12 @@ class TypeDefWriterTest {
     @ParameterizedTest
     @MethodSource("multipleCastArguments")
     fun `test typedef write with multiple casts`(typeDef: TypeDefSpec, expected: String) {
+        Truth.assertThat(typeDef.toString()).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @MethodSource("differentParameterTypes")
+    fun `test typedef write with different parameter types`(typeDef: TypeDefSpec, expected: String) {
         Truth.assertThat(typeDef.toString()).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -108,7 +108,8 @@ class FunctionSpecTest {
     @ParameterizedTest
     @MethodSource("testParameterGeneration")
     fun `test different parameter variants in combination`(specBuilder: () -> FunctionSpec, expected: String) {
-        assertEquals(expected, specBuilder.invoke().toString())
+        val spec = specBuilder.invoke()
+        assertEquals(expected, spec.toString())
     }
 
     @Test

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
@@ -1,11 +1,45 @@
 package net.theevilreaper.dartpoet.parameter
 
+import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 import kotlin.test.assertContentEquals
 
 class ParameterSpecTest {
+
+    companion object {
+
+        @JvmStatic
+        private fun parameterVariants(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                { ParameterSpec.builder("amount", Int::class).modifiers(DartModifier.REQUIRED) },
+                "required int amount"
+            ),
+            Arguments.of(
+                { ParameterSpec.builder("name", String::class).initializer("%C", "theEvilReaper") },
+                "String name = 'theEvilReaper'"
+            ),
+            Arguments.of(
+                {
+                    ParameterSpec.builder("name", String::class).named(true).initializer("%C", "theEvilReaper")
+                },
+                "String name = 'theEvilReaper'"
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameterVariants")
+    fun `test parameter spec builder`(specBuilder: () -> ParameterBuilder, expected: String) {
+        val parameterSpec = specBuilder.invoke().build()
+        assertNotNull(parameterSpec)
+        assertEquals(expected, parameterSpec.toString())
+    }
 
     @Test
     fun `test spec to builder conversation`() {


### PR DESCRIPTION
## Proposed changes

The programming language `Dart` has different properties for the parameters which a function or typedef can have. Each property has an impact about how the function aligns the parameter to it. At the moment the state of the parameter generation doesn't recognize the specific property. The result of the generation is wrong generated code for `Dart`.

The following snippet contains some variants of the different parameter generation which should be supported

```dart
abstract void print(String text, [String additional = 'Test']);

abstract void print(String text, {required String additional});

abstract void print(string text, {String additional = 'Test'});
```

- [x]  Implement default generation
- [x] Implement required generation
- [x] Implement last option

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)