### PR TITLE
Fix invalid name pattern

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -33,7 +33,7 @@ internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.CONST)
 internal val ALLOWED_CONST_MODIFIERS = setOf(DartModifier.STATIC, DartModifier.CONST)
 
 //RegEx
-private val namePattern: Regex = Regex("[a-z]+|([a-z]+)_+([a-z]+)")
+private val namePattern: Regex = Regex("^[a-z]+(?:_[a-z]+)*\$")
 private val lowerCamelCase: Regex = Regex("[a-z]+[A-Z0-9]*[a-z0-9]*[A-Za-z0-9]*")
 private val indentPattern: Regex = Regex(" +")
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -7,7 +7,6 @@ import net.theevilreaper.dartpoet.code.buildCodeBlock
 import net.theevilreaper.dartpoet.directive.CastType
 import net.theevilreaper.dartpoet.directive.DirectiveFactory
 import net.theevilreaper.dartpoet.directive.DirectiveType
-import net.theevilreaper.dartpoet.enum.EnumPropertySpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.function.typedef.TypeDefSpec

--- a/src/test/kotlin/net/theevilreaper/dartpoet/util/ConstantsTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/util/ConstantsTest.kt
@@ -1,12 +1,10 @@
 package net.theevilreaper.dartpoet.util
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class ConstantsTest {
 
@@ -18,13 +16,11 @@ class ConstantsTest {
             Arguments.of("Dart_FILE", false),
             Arguments.of("item_model", true),
             Arguments.of("item_model.dart", true),
-            Arguments.of("model.dart", true)
-        )
-
-        @JvmStatic
-        private fun camelCaseFormatting() = Stream.of(
-            Arguments.of("testA", formatLowerCamelCase("testA")),
-            Arguments.of("thisIsCamelCase", formatLowerCamelCase("thisisCamelcase"))
+            Arguments.of("model.dart", true),
+            Arguments.of("model_", false),
+            Arguments.of("boss_bar_colour_meep", true),
+            Arguments.of("hello__world.dart", false),
+            Arguments.of("_hello__world_.dart", false),
         )
     }
 


### PR DESCRIPTION
## Proposed changes

The current name pattern, which checks, if a given name for a file is valid for Dart, doesn't allow the usage of multiple underscores and name parts. This pull request fixes this issue #86.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...