### PR TITLE
Fix missing `this` call on parameters which don't have a type

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
@@ -31,6 +31,9 @@ internal class ParameterWriter : Writeable<ParameterSpec>, InitializerAppender<P
         }
         val emitNullable = if (spec.isNullable) "?·" else if (spec.type != null) "·" else EMPTY_STRING
         writer.emit(emitNullable)
+        if (spec.hasNoTypeName) {
+            writer.emit("this.")
+        }
         writer.emit(spec.name)
         writeInitBlock(spec, writer)
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -132,14 +132,20 @@ class FunctionBuilder internal constructor(
     }
 
     fun parameter(parameter: ParameterSpec) = apply {
+        check(!parameter.hasNoTypeName) { "Parameter must have a type" }
         this.parameters += parameter
     }
 
     fun parameter(parameter: () -> ParameterSpec) = apply {
+        check(!parameter().hasNoTypeName) { "Parameter must have a type" }
         this.parameters += parameter()
     }
 
     fun parameters(vararg parameters: ParameterSpec) = apply {
+        if (parameters.isEmpty()) return@apply
+        parameters.forEach {
+            check(!it.hasNoTypeName) { "Parameter must have a type" }
+        }
         this.parameters += parameters
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -10,6 +10,7 @@ import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.type.asClassName
 import net.theevilreaper.dartpoet.type.asTypeName
+import net.theevilreaper.dartpoet.util.NO_PARAMETER_TYPE
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 
@@ -132,19 +133,19 @@ class FunctionBuilder internal constructor(
     }
 
     fun parameter(parameter: ParameterSpec) = apply {
-        check(!parameter.hasNoTypeName) { "Parameter must have a type" }
+        check(!parameter.hasNoTypeName) { NO_PARAMETER_TYPE }
         this.parameters += parameter
     }
 
     fun parameter(parameter: () -> ParameterSpec) = apply {
-        check(!parameter().hasNoTypeName) { "Parameter must have a type" }
+        check(!parameter().hasNoTypeName) { NO_PARAMETER_TYPE }
         this.parameters += parameter()
     }
 
     fun parameters(vararg parameters: ParameterSpec) = apply {
         if (parameters.isEmpty()) return@apply
         parameters.forEach {
-            check(!it.hasNoTypeName) { "Parameter must have a type" }
+            check(!it.hasNoTypeName) { NO_PARAMETER_TYPE }
         }
         this.parameters += parameters
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -34,6 +34,7 @@ class ParameterSpec internal constructor(
     internal val initializer = builder.initializer
     internal val annotations = builder.specData.annotations.toImmutableSet()
     internal val hasInitializer = initializer != null && initializer.isNotEmpty()
+    internal val hasNoTypeName: Boolean = builder.typeName == null
 
     /**
      * This init block is responsible for performing initial checks on the name parameter.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -39,6 +39,9 @@ private val indentPattern: Regex = Regex(" +")
 
 internal val ALLOWED_PRIMITIVE_TYPES = setOf("Short", "Int", "Long", "Float", "Double", "Char", "Boolean")
 
+//Error message
+internal const val NO_PARAMETER_TYPE = "Parameter must have a type"
+
 /**
  * Checks if a given set of [DartModifier] matches with a given set which contains the allowed [DartModifier].
  * @param rawModifiers contains all modifiers from the context

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileTest.kt
@@ -366,7 +366,7 @@ class DartFileTest {
               String name;
             
               /// Good comment
-              TestModel(name);
+              TestModel(this.name);
             
               /// Returns the given name from the object
               String getName() {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/EnumClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/EnumClassTest.kt
@@ -120,10 +120,35 @@ class EnumClassTest {
               final String name;
               final String route;
             
-              const NavigationEntry(name, route);
+              const NavigationEntry(this.name, this.route);
             
             }
             """.trimIndent()
         )
     }
+
+    @Test
+    fun d() {
+        val enumClass = ClassSpec.enumClass("TestEnum")
+            .enumProperties(
+                EnumPropertySpec.builder("test")
+                    .parameter("%C", "Test")
+                    .build()
+            )
+            .properties(
+                PropertySpec.builder("name", String::class).build()
+            )
+            .constructor(
+                ConstructorSpec.builder("TestEnum")
+                    .parameter(ParameterSpec.builder("name").build())
+                    .build()
+            )
+            .build()
+        val file = DartFile.builder("test")
+            .type(enumClass)
+            .build()
+        file.write(System.out)
+    }
 }
+
+

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
@@ -21,7 +21,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Car(maker, model, yearMade, hasABS);
+            Car(this.maker, this.model, this.yearMade, this.hasABS);
             """.trimIndent()
         )
     }
@@ -37,7 +37,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Car.withoutABS(maker, model, yearMade);
+            Car.withoutABS(this.maker, this.model, this.yearMade);
             """.trimIndent()
         )
     }
@@ -58,7 +58,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Car.withoutABS(maker, model, yearMade): hasABS = false;
+            Car.withoutABS(this.maker, this.model, this.yearMade): hasABS = false;
             """.trimIndent()
         )
     }
@@ -75,7 +75,7 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            const Car(maker, model, yearMade);
+            const Car(this.maker, this.model, this.yearMade);
             """.trimIndent()
         )
     }
@@ -92,9 +92,9 @@ class ConstructorWriterTest {
         assertThat(constructor.toString()).isEqualTo(
             """
             Car({
-              required maker,
-              model,
-              required yearMade
+              required this.maker,
+              this.model,
+              required this.yearMade
             });
             """.trimIndent()
         )
@@ -111,10 +111,10 @@ class ConstructorWriterTest {
             .build()
         assertThat(constructor.toString()).isEqualTo(
             """
-            Item(id = 10,
+            Item(this.id = 10,
             {
-              required name,
-              required amount
+              required this.name,
+              required this.amount
             });
             """.trimIndent()
         )
@@ -130,7 +130,7 @@ class ConstructorWriterTest {
         assertThat(constructor.toString()).isEqualTo(
             """
             /// Creates a new item object
-            Item(name);
+            Item(this.name);
             """.trimIndent()
         )
     }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -2,8 +2,8 @@ package net.theevilreaper.dartpoet.function
 
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
-import net.theevilreaper.dartpoet.type.INTEGER
 import net.theevilreaper.dartpoet.type.asTypeName
+import net.theevilreaper.dartpoet.util.NO_PARAMETER_TYPE
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -90,12 +90,41 @@ class FunctionSpecTest {
                         .modifiers(DartModifier.ABSTRACT)
                         .parameters(
                             ParameterSpec.builder("text", String::class).build(),
-                            ParameterSpec.builder("additional", String::class).initializer("%C", "Hello World!").build(),
+                            ParameterSpec.builder("additional", String::class).initializer("%C", "Hello World!")
+                                .build(),
                         )
                         .build()
                 },
                 "abstract void print(String text, [String additional = 'Hello World!']);"
             ),
+        )
+
+        @JvmStatic
+        private fun invalidFunctionParameters() = Stream.of(
+            Arguments.of(
+                {
+                    FunctionSpec.builder("Test")
+                        .parameter(ParameterSpec.builder("name").build())
+                },
+                NO_PARAMETER_TYPE
+            ),
+            Arguments.of(
+                {
+                    FunctionSpec.builder("Test")
+                        .parameter { ParameterSpec.builder("name").build() }
+                },
+                NO_PARAMETER_TYPE
+            ),
+            Arguments.of(
+                {
+                    FunctionSpec.builder("Test")
+                        .parameters(
+                            ParameterSpec.builder("test", String::class).build(),
+                            ParameterSpec.builder("name").build()
+                        )
+                },
+                NO_PARAMETER_TYPE
+            )
         )
     }
 
@@ -110,6 +139,12 @@ class FunctionSpecTest {
     fun `test different parameter variants in combination`(specBuilder: () -> FunctionSpec, expected: String) {
         val spec = specBuilder.invoke()
         assertEquals(expected, spec.toString())
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidFunctionParameters")
+    fun `test invalid parameters on functions`(specBuilder: () -> Unit, expected: String) {
+        assertThrows(IllegalStateException::class.java, specBuilder, expected)
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

When a  property is marked as final so the counterpart in the constructor must contains the final keyword. At the moment the library doesn't care about it which results in a invalid generation. The pull request fixes #86 

TODO:

- [x] Add tests

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...