### PR TITLE
Add nullable option to the PropertySpec builder

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
@@ -37,6 +37,9 @@ internal class PropertyWriter : Writeable<PropertySpec>, DocumentationAppender,
 
         if (spec.type != null) {
             writer.emitCode("%T", spec.type)
+            if (spec.nullable) {
+                writer.emit("?")
+            }
             writer.emitSpace()
         }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriter.kt
@@ -3,6 +3,7 @@ package net.theevilreaper.dartpoet.code.writer
 import net.theevilreaper.dartpoet.code.*
 import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import net.theevilreaper.dartpoet.util.SEMICOLON
 import net.theevilreaper.dartpoet.util.SPACE
@@ -24,9 +25,7 @@ internal class PropertyWriter : Writeable<PropertySpec>, DocumentationAppender,
      */
     override fun write(spec: PropertySpec, writer: CodeWriter) {
         emitDocumentation(spec.docs, writer)
-        spec.annotations.emitAnnotations(writer) {
-            it.write(writer, inline = false)
-        }
+        spec.annotations.emitAnnotations(writer) { it.write(writer, inline = false) }
 
         val modifierString = StringHelper.concatData(
             spec.modifiers,
@@ -36,9 +35,9 @@ internal class PropertyWriter : Writeable<PropertySpec>, DocumentationAppender,
         writer.emit(modifierString)
 
         if (spec.type != null) {
-            writer.emitCode("%T", spec.type)
-            if (spec.nullable) {
-                writer.emit("?")
+            when (spec.canEmitNullable) {
+                true -> writer.emitCode("%T%L", spec.type, "?")
+                else -> writer.emitCode("%T", spec.type)
             }
             writer.emitSpace()
         }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertyBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertyBuilder.kt
@@ -19,14 +19,16 @@ class PropertyBuilder internal constructor(
 ) {
     internal val modifiers: MutableSet<DartModifier> = mutableSetOf()
     internal val annotations: MutableList<AnnotationSpec> = mutableListOf()
-    internal var initBlock: CodeBlock.Builder = CodeBlock.builder()
     internal val docs: MutableList<CodeBlock> = mutableListOf()
+    internal var nullable: Boolean = false
+    internal var initBlock: CodeBlock.Builder = CodeBlock.builder()
 
     /**
      * Add a comment over for the extension class.
      * Note this comments will be generated over the extension class
      * @param format the string which contains the content and the format
      * @param args the arguments for the format string
+     * @return the current [PropertyBuilder] instance
      */
     fun docs(format: String, vararg args: Any) = apply {
         this.docs.add(CodeBlock.of(format.replace(' ', '·'), *args))
@@ -36,6 +38,7 @@ class PropertyBuilder internal constructor(
      * Apply a given format which contains the parts for the init block of the [PropertySpec].
      * @param format the given format
      * @param args the arguments for the format
+     * @return the current [PropertyBuilder] instance
      */
     fun initWith(format: String, vararg args: Any?): PropertyBuilder = apply {
         this.initBlock.add(format, *args)
@@ -44,6 +47,7 @@ class PropertyBuilder internal constructor(
     /**
      * Set the initializer block directly as [CodeBlock.Builder] to the property.
      * @param codeFragment the [CodeBlock.Builder] to set
+     * @return the current [PropertyBuilder] instance
      */
     fun initWith(codeFragment: CodeBlock.Builder): PropertyBuilder = apply {
         this.initBlock = codeFragment
@@ -52,6 +56,7 @@ class PropertyBuilder internal constructor(
     /**
      * Add a single [AnnotationSpec] to the property.
      * @param annotation the annotation to add
+     * @return the current [PropertyBuilder] instance
      */
     fun annotation(annotation: () -> AnnotationSpec): PropertyBuilder = apply {
         this.annotations += annotation()
@@ -60,6 +65,7 @@ class PropertyBuilder internal constructor(
     /**
      * Add a single [AnnotationSpec] to the property.
      * @param annotation the annotation to add
+     * @return the current [PropertyBuilder] instance
      */
     fun annotation(annotation: AnnotationSpec): PropertyBuilder = apply {
         this.annotations += annotation
@@ -68,14 +74,24 @@ class PropertyBuilder internal constructor(
     /**
      * Add a new [DartModifier] to the property.
      * @param modifier the modifier to add
+     * @return the current [PropertyBuilder] instance
      */
     fun modifier(modifier: DartModifier): PropertyBuilder = apply {
         this.modifiers += modifier
     }
 
     /**
+     * Marks the property as nullable
+     * @return the current [PropertyBuilder] instance
+     */
+    fun nullable(): PropertyBuilder = apply {
+        nullable = !nullable
+    }
+
+    /**
      * Add a new [DartModifier] to the property.
      * @param modifier the modifier to add
+     * @return the current [PropertyBuilder] instance
      */
     fun modifier(modifier: () -> DartModifier): PropertyBuilder = apply {
         this.modifiers += modifier()
@@ -84,6 +100,7 @@ class PropertyBuilder internal constructor(
     /**
      * Add an [Array] of [DartModifier]'s to the property.
      * @param modifiers the modifier values to add
+     * @return the current [PropertyBuilder] instance
      */
     fun modifiers(vararg modifiers: DartModifier) = apply {
         this.modifiers += modifiers
@@ -93,7 +110,5 @@ class PropertyBuilder internal constructor(
      * Creates a new reference from the [PropertySpec] with the given builder reference.
      * @return the created [PropertySpec] instance
      */
-    fun build(): PropertySpec {
-        return PropertySpec(this)
-    }
+    fun build(): PropertySpec = PropertySpec(this)
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
@@ -27,6 +27,7 @@ class PropertySpec internal constructor(
 ) {
     internal var name = builder.name
     internal var type = builder.type
+    internal val nullable = builder.nullable
     internal var annotations: Set<AnnotationSpec> = builder.annotations.toImmutableSet()
     internal var initBlock = builder.initBlock
     internal var isPrivate = builder.modifiers.contains(DartModifier.PRIVATE)
@@ -48,6 +49,7 @@ class PropertySpec internal constructor(
     init {
         require(name.trim().isNotEmpty()) { "The name of a property can't be empty" }
         require(!(builder.type == null && !isConst)) { "Only a const property can have no type" }
+        check(!(builder. type == null && nullable)) { "A nullable property needs a type" }
         require(!(isConst && this.initBlock.isEmpty())) { "A const variable needs an init block" }
     }
 
@@ -77,6 +79,7 @@ class PropertySpec internal constructor(
         builder.initBlock = this.initBlock
         builder.docs.addAll(this.docs)
         builder.modifiers.addAll(this.modifiers)
+        builder.nullable = nullable
         return builder
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/property/PropertySpec.kt
@@ -45,6 +45,7 @@ class PropertySpec internal constructor(
             }
         }.filter { it != DartModifier.PRIVATE && it != DartModifier.PUBLIC }.toImmutableSet()
     internal val hasModifiers: Boolean = modifiers.isNotEmpty()
+    internal val canEmitNullable: Boolean = nullable && type != null && !type!!.isNullable
 
     init {
         require(name.trim().isNotEmpty()) { "The name of a property can't be empty" }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
@@ -4,14 +4,17 @@ import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.type.asTypeName
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
-import kotlin.test.assertEquals
 
 @DisplayName("Test property writer")
 class PropertyWriterTest {
@@ -72,6 +75,17 @@ class PropertyWriterTest {
     }
 
     @Test
+    fun `test property which should not have double nullable marker`() {
+        val typeName: TypeName = String::class.asTypeName().copy(nullable = true)
+        assertNotNull(typeName)
+        assertTrue(typeName.isNullable)
+
+        val property: PropertySpec = PropertySpec.builder("test", typeName).nullable().build()
+        assertThat(property.toString()).isEqualTo("String? test;")
+        assertThat(property.toString()).isNotEqualTo("String?? test;")
+    }
+
+    @Test
     fun `write simple variable with one annotation`() {
         val property = PropertySpec.builder("age", Int::class)
             .annotation { AnnotationSpec.builder("jsonIgnore").build() }
@@ -113,5 +127,13 @@ class PropertyWriterTest {
             String? name;
             """.trimIndent()
         )
+    }
+
+    @Test
+    fun `test property which is nullable`() {
+        val property = PropertySpec.builder("name", String::class).nullable().build()
+        assertNotNull(property)
+        assertTrue(property.nullable)
+        assertThat(property.toString()).isEqualTo("String? name;")
     }
 }


### PR DESCRIPTION
## Proposed changes

This pull request addresses issue #159, which notes that the `PropertySpec` builder lacks a method to mark a property as nullable. This feature has now been implemented.

Closes #159 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)