### PR TITLE
Remove deprecated `from` method in EnumParameterSpec

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/enum/parameter/EnumParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/enum/parameter/EnumParameterSpec.kt
@@ -121,18 +121,6 @@ class EnumParameterSpec internal constructor(
             variableRef,
             nullable = true
         )
-
-        /**
-         * Creates a new [EnumParameterSpec] instance with the given [format] and [args].
-         * @param format the format string
-         * @param args the arguments for the format string
-         * @return the created instance
-         */
-        @JvmStatic
-        @Deprecated("Use positional instead")
-        fun from(format: String, vararg args: Any): EnumParameterSpec = EnumParameterSpec(
-            CodeBlock.of(format, *args),
-        )
     }
 }
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/EnumClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/EnumClassTest.kt
@@ -40,8 +40,8 @@ class EnumClassTest {
                     ClassSpec.enumClass("TestEnum")
                         .enumProperties(
                             EnumEntrySpec.builder("test")
-                                .parameter(EnumParameterSpec.from("%C", "Test"))
-                                .parameter(EnumParameterSpec.from("%L", "10"))
+                                .parameter(EnumParameterSpec.positional("%C", "Test"))
+                                .parameter(EnumParameterSpec.positional("%L", "10"))
                                 .build()
                         )
                         .property(PropertySpec.builder("name", String::class).build())
@@ -94,18 +94,18 @@ class EnumClassTest {
                     .enumProperties(
                         EnumEntrySpec.builder("dashboard")
                             .parameter {
-                                EnumParameterSpec.from("%C", "Dashboard")
+                                EnumParameterSpec.positional("%C", "Dashboard")
                             }
                             .parameter {
-                                EnumParameterSpec.from("%C", "/dashboard")
+                                EnumParameterSpec.positional("%C", "/dashboard")
                             }
                             .build(),
                         EnumEntrySpec.builder("build")
                             .parameter {
-                                EnumParameterSpec.from("%C", "Build")
+                                EnumParameterSpec.positional("%C", "Build")
                             }
                             .parameter {
-                                EnumParameterSpec.from("%C", "/build")
+                                EnumParameterSpec.positional("%C", "/build")
                             }
                             .build()
                     )

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/EnumEntrySpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/EnumEntrySpecTest.kt
@@ -21,7 +21,7 @@ class EnumEntrySpecTest {
             Arguments.of(
                 EnumEntrySpec.builder("test")
                     .parameter(
-                        EnumParameterSpec.from("%C", "/dash")
+                        EnumParameterSpec.positional("%C", "/dash")
                     )
                     .build(),
                 "test('/dash')"
@@ -29,16 +29,16 @@ class EnumEntrySpecTest {
             Arguments.of(
                 EnumEntrySpec.builder("test")
                     .parameter(
-                        EnumParameterSpec.from("%L", "10")
+                        EnumParameterSpec.positional("%L", "10")
                     )
                     .build(),
                 "test(10)"
             ),
             Arguments.of(
                 EnumEntrySpec.builder("dashboard")
-                    .parameter(EnumParameterSpec.from("%C", "Dashboard"))
-                    .parameter(EnumParameterSpec.from("%C", "/dashboard"))
-                    .parameter(EnumParameterSpec.from("%L", "false"))
+                    .parameter(EnumParameterSpec.positional("%C", "Dashboard"))
+                    .parameter(EnumParameterSpec.positional("%C", "/dashboard"))
+                    .parameter(EnumParameterSpec.positional("%L", "false"))
                     .build(),
                 "dashboard('Dashboard', '/dashboard', false)"
             ),

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
@@ -20,7 +20,6 @@ import java.util.stream.Stream
 class PropertyWriterTest {
 
     companion object {
-
         @JvmStatic
         private fun simpleProperties(): Stream<Arguments> = Stream.of(
             Arguments.of(PropertySpec.builder("id", Int::class).build(), "int id;"),

--- a/src/test/kotlin/net/theevilreaper/dartpoet/enumeration/EnumEntrySpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/enumeration/EnumEntrySpecTest.kt
@@ -26,7 +26,7 @@ class EnumEntrySpecTest {
             Arguments.of(EnumEntrySpec.builder("test").generic(String::class).build(), "test<String>"),
             Arguments.of(
                 EnumEntrySpec.builder("navigation")
-                    .parameter(EnumParameterSpec.from("%C", "/dashboard"))
+                    .parameter(EnumParameterSpec.positional("%C", "/dashboard"))
                     .build(),
                 "navigation('/dashboard')"
             )
@@ -56,7 +56,7 @@ class EnumEntrySpecTest {
         val propertySpec = EnumEntrySpec
             .builder("test")
             .generic(String::class)
-            .parameter(EnumParameterSpec.from("%C", "/dashboard"))
+            .parameter(EnumParameterSpec.positional("%C", "/dashboard"))
             .build()
         val specAsBuilder = propertySpec.toBuilder()
         assertNotNull(specAsBuilder)

--- a/src/test/kotlin/net/theevilreaper/dartpoet/enumeration/parameter/EnumParameterSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/enumeration/parameter/EnumParameterSpecTest.kt
@@ -11,7 +11,7 @@ class EnumParameterSpecTest {
     @Test
     fun `test enum parameter creation with empty code block`() {
         assertThrows<IllegalStateException>("The data block can't be empty") {
-            EnumParameterSpec.from(EMPTY_STRING, EMPTY_STRING, false)
+            EnumParameterSpec.positional(EMPTY_STRING, EMPTY_STRING, false)
         }
     }
 
@@ -31,7 +31,7 @@ class EnumParameterSpecTest {
 
     @Test
     fun `test enum parameter creation`() {
-        val parameter = EnumParameterSpec.from("%C", "test")
+        val parameter = EnumParameterSpec.positional("%C", "test")
         assertNotNull(parameter)
         assertNotNull(parameter.dataBlock)
         assertEquals(1, parameter.dataBlock.args.size)


### PR DESCRIPTION
## Proposed changes

The `EnumParameterSpec` class includes a deprecated `from` method, which duplicates the functionality of the positional method in the companion object. This method is a remnant of an older implementation, which has since been revised. This pull request removes the `from` method to prevent potential issues in the future.

Closes #163

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)