### PR TITLE
Add support for the covariant keyword on parameters

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartModifier.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartModifier.kt
@@ -28,7 +28,9 @@ enum class DartModifier(
     TYPEDEF("typedef", ModifierTarget.TYPEDEF),
     DYNAMIC("dynamic", ModifierTarget.PARAMETER),
     REQUIRED("required", ModifierTarget.PARAMETER),
-    VOID("void", ModifierTarget.INTERFACE, ModifierTarget.FUNCTION);
+    VOID("void", ModifierTarget.INTERFACE, ModifierTarget.FUNCTION),
+    CO_VARIANT("covariant", ModifierTarget.PARAMETER)
+    ;
 
     /**
      * Checks if an [ModifierTarget] is present in a specific [DartModifier].

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
@@ -28,6 +28,11 @@ internal class ParameterWriter : Writeable<ParameterSpec>, InitializerAppender<P
             writer.emitSpace()
         }
 
+        if (spec.coVariant) {
+            writer.emit(DartModifier.CO_VARIANT.identifier)
+            writer.emitSpace()
+        }
+
         if (spec.typeName != null) {
             writer.emitCode("%T", spec.typeName)
         }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterBuilder.kt
@@ -26,6 +26,7 @@ class ParameterBuilder internal constructor(
     internal val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal var named: Boolean = false
     internal var nullable: Boolean = false
+    internal var coVariant: Boolean = false
     internal var initializer: CodeBlock? = null
 
     /**
@@ -54,6 +55,15 @@ class ParameterBuilder internal constructor(
      */
     fun nullable(nullable: Boolean) = apply {
         this.nullable = nullable
+    }
+
+    /**
+     * Updates the indication value if a parameter should adds the `coVariant` modifier.
+     * @param coVariant true if the parameter should be co-variant, false otherwise
+     * @return the current [ParameterBuilder] instance
+     */
+    fun coVariant(coVariant: Boolean) = apply {
+        this.coVariant = coVariant
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -34,6 +34,7 @@ class ParameterSpec internal constructor(
     internal val isNullable = nullable
     internal val initializer = builder.initializer
     internal val annotations = builder.annotations.toImmutableSet()
+    internal val coVariant = builder.coVariant
     internal val hasInitializer = initializer != null && initializer.isNotEmpty()
     internal val hasNoTypeName: Boolean = builder.typeName == null
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/CoVariantParameterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/CoVariantParameterTest.kt
@@ -1,0 +1,37 @@
+package net.theevilreaper.dartpoet.parameter
+
+import com.google.common.truth.Truth.*
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.ModifierTarget
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.type.asClassName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoVariantParameterTest {
+
+    @Test
+    fun `test co-variant parameter`() {
+        val parameter = ParameterSpec.positional("param", String::class)
+            .coVariant(true)
+            .build()
+
+        assertNotNull(parameter)
+        assertTrue(parameter.coVariant)
+        assertEquals(String::class.asClassName(), parameter.typeName)
+
+        assertEquals("covariant String param", parameter.toString())
+
+        val method = FunctionSpec.builder("print")
+            .parameter { parameter }
+            .returns(Void::class)
+            .modifiers(DartModifier.ABSTRACT)
+            .build()
+
+        assertThat(method.toString()).isEqualTo("""
+            abstract void print(covariant String param);
+        """.trimIndent())
+    }
+}


### PR DESCRIPTION
## Proposed changes

The pull request adds the support for the `covariant` keyword on parameters. This helps to improve code generation which relies on a generic context.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)