### PR TITLE
 feat(class): add support for sealed/base/interface modifiers

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -2,7 +2,6 @@ package net.theevilreaper.dartpoet.clazz
 
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.DartModifier.CLASS
-import net.theevilreaper.dartpoet.DartModifier.WITH
 import net.theevilreaper.dartpoet.InheritKeyword
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.code.CodeWriter
@@ -17,6 +16,7 @@ import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.util.toImmutableList
 import net.theevilreaper.dartpoet.util.toImmutableSet
+import net.theevilreaper.dartpoet.util.EXCLUSIVE_CLASS_MODIFIERS
 
 /**
  * A [ClassBuilder] describes the actual content of the class.
@@ -41,7 +41,6 @@ class ClassSpec internal constructor(
     internal val isLibrary: Boolean = builder.classType == ClassType.LIBRARY
     internal val superClass: TypeName? = builder.superClass
     internal val inheritKeyWord: InheritKeyword? = builder.inheritKeyWord
-    internal val classModifiers: Set<DartModifier> = modifiers.filter { it != WITH }.toImmutableSet()
     internal val typeDefs: List<AbstractTypeDef<*>> = builder.typedefs.toImmutableList()
     internal val functions: Set<FunctionSpec> = builder.functionStack.toImmutableSet()
     internal val properties: Set<PropertySpec> = builder.propertyStack.toImmutableSet()
@@ -67,6 +66,16 @@ class ClassSpec internal constructor(
 
             enumPropertyStack.forEach {
                 check(it.parameters.size == propertiesSize) { "The entries from the enum property must have the same size" }
+            }
+        }
+
+        if (classType == ClassType.CLASS || classType == ClassType.ABSTRACT) {
+            val exclusiveModifiers = modifiers.intersect(EXCLUSIVE_CLASS_MODIFIERS)
+            check(exclusiveModifiers.size <= 1) {
+                "A class can only have one of these modifiers at the same time: $EXCLUSIVE_CLASS_MODIFIERS, but got: $exclusiveModifiers"
+            }
+            check(!(isAbstract && DartModifier.SEALED in modifiers)) {
+                "A sealed class can't be combined with the abstract modifier because sealed classes are implicitly abstract"
             }
         }
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -1,6 +1,5 @@
 package net.theevilreaper.dartpoet.code.writer
 
-import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.DartModifier.*
 import net.theevilreaper.dartpoet.clazz.ClassType
 import net.theevilreaper.dartpoet.clazz.ClassSpec
@@ -135,12 +134,15 @@ internal class ClassWriter : Writeable<ClassSpec> {
      */
     private fun writeClassHeader(spec: ClassSpec, writer: CodeWriter) {
         if (spec.classType == ClassType.LIBRARY) return
-        val finalModifier = StringHelper.createModifierString(spec.modifiers.filter { it == FINAL })
+        val exclusiveModifier = when (spec.classType) {
+            ClassType.CLASS, ClassType.ABSTRACT -> StringHelper.createModifierString(spec.modifiers.filter { it in EXCLUSIVE_CLASS_MODIFIERS })
+            else -> EMPTY_STRING
+        }
 
         val headerPrefix = when (spec.classType) {
-            ClassType.ABSTRACT -> "${ABSTRACT.identifier} $finalModifier${CLASS.identifier}"
-            ClassType.CLASS -> "$finalModifier${CLASS.identifier}"
-            else -> "$finalModifier${spec.classType.keyword}"
+            ClassType.ABSTRACT -> "${ABSTRACT.identifier} $exclusiveModifier${CLASS.identifier}"
+            ClassType.CLASS -> "$exclusiveModifier${CLASS.identifier}"
+            else -> "$exclusiveModifier${spec.classType.keyword}"
         }
 
         writer.emitCode("%L", headerPrefix)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/Constants.kt
@@ -34,6 +34,7 @@ internal val ALLOWED_PROPERTY_MODIFIERS =
     setOf(DartModifier.PRIVATE, DartModifier.FINAL, DartModifier.LATE, DartModifier.STATIC, DartModifier.CONST, DartModifier.CO_VARIANT)
 internal val ALLOWED_CLASS_CONST_MODIFIERS = setOf(DartModifier.CONST)
 internal val ALLOWED_CONST_MODIFIERS = setOf(DartModifier.STATIC, DartModifier.CONST)
+internal val EXCLUSIVE_CLASS_MODIFIERS = setOf(DartModifier.BASE, DartModifier.INTERFACE, DartModifier.FINAL, DartModifier.SEALED)
 
 //RegEx
 private val namePattern: Regex = Regex("^[a-z]+(?:_[a-z]+)*\$")

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassModifierTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassModifierTest.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.dartpoet.classTypes
 
+import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import org.junit.jupiter.api.DisplayName
@@ -10,8 +11,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.test.assertEquals
 
-@DisplayName("Test the validation of exclusive class modifiers")
-class ClassModifierValidationTest {
+@DisplayName("Test the exclusive class modifiers (base/interface/final/sealed)")
+class ClassModifierTest {
 
     companion object {
 
@@ -44,6 +45,42 @@ class ClassModifierValidationTest {
                 "A sealed class can't be combined with the abstract modifier because sealed classes are implicitly abstract"
             )
         )
+
+        @JvmStatic
+        private fun exclusiveModifierClasses() = Stream.of(
+            Arguments.of(
+                ClassSpec.builder("Handler").modifier { DartModifier.FINAL }.build(),
+                "final class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Shape").modifier { DartModifier.SEALED }.build(),
+                "sealed class Shape {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Handler").modifier { DartModifier.BASE }.build(),
+                "base class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Handler").modifier { DartModifier.INTERFACE }.build(),
+                "interface class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.abstractClass("Handler").modifier { DartModifier.FINAL }.build(),
+                "abstract final class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.abstractClass("Handler").modifier { DartModifier.BASE }.build(),
+                "abstract base class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.abstractClass("Handler").modifier { DartModifier.INTERFACE }.build(),
+                "abstract interface class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.mixinClass("Handler").modifier { DartModifier.BASE }.build(),
+                "mixin Handler {}"
+            )
+        )
     }
 
     @ParameterizedTest(name = "Test cases for invalid class modifier combinations")
@@ -51,5 +88,11 @@ class ClassModifierValidationTest {
     fun `test invalid class modifier combination`(classSpec: () -> Unit, message: String) {
         val exception = assertThrows<IllegalStateException> { classSpec() }
         assertEquals(message, exception.message)
+    }
+
+    @ParameterizedTest(name = "Test cases for the exclusive class modifiers (base/interface/final/sealed)")
+    @MethodSource("exclusiveModifierClasses")
+    fun `test exclusive modifier classes`(classSpec: ClassSpec, expected: String) {
+        assertThat(classSpec.toString()).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassModifierValidationTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassModifierValidationTest.kt
@@ -1,0 +1,55 @@
+package net.theevilreaper.dartpoet.classTypes
+
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+
+@DisplayName("Test the validation of exclusive class modifiers")
+class ClassModifierValidationTest {
+
+    companion object {
+
+        @JvmStatic
+        private fun invalidModifierCombinations() = Stream.of(
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifier { DartModifier.BASE }
+                        .modifier { DartModifier.INTERFACE }
+                        .build()
+                },
+                "A class can only have one of these modifiers at the same time: [BASE, INTERFACE, FINAL, SEALED], but got: [BASE, INTERFACE]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifier { DartModifier.SEALED }
+                        .modifier { DartModifier.FINAL }
+                        .build()
+                },
+                "A class can only have one of these modifiers at the same time: [BASE, INTERFACE, FINAL, SEALED], but got: [SEALED, FINAL]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.abstractClass("Handler")
+                        .modifier { DartModifier.SEALED }
+                        .build()
+                },
+                "A sealed class can't be combined with the abstract modifier because sealed classes are implicitly abstract"
+            )
+        )
+    }
+
+    @ParameterizedTest(name = "Test cases for invalid class modifier combinations")
+    @MethodSource("invalidModifierCombinations")
+    fun `test invalid class modifier combination`(classSpec: () -> Unit, message: String) {
+        val exception = assertThrows<IllegalStateException> { classSpec() }
+        assertEquals(message, exception.message)
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
@@ -41,10 +41,6 @@ class ClassWriterTest {
                 |abstract class DatabaseHandler {}
                 |
                 """.trimMargin()
-            ),
-            Arguments.of(
-                ClassSpec.abstractClass("Handler").modifier { DartModifier.FINAL }.build(),
-                "abstract final class Handler {}"
             )
         )
     }


### PR DESCRIPTION
## Proposed changes

Adds rendering and validation for Dart's `sealed`/`base`/`interface` class modifiers, which existed as `DartModifier` values but were never emitted by the `ClassWriter` (only `final` was hardcoded). Also removes an unused dead field on `ClassSpec` and  reorganizes the related tests into their own `ClassModifierTest.kt`.                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                   
`mixin class` combinations are intentionally out of scope for this PR.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

`mixin class` support and multi-mixin/-interface headers are planned as follow-ups