### PR TITLE
feat(ci): add Dart analyzer verification pipeline

### DIFF
--- a/.github/workflows/dart-analyze.yml
+++ b/.github/workflows/dart-analyze.yml
@@ -1,0 +1,20 @@
+name: Dart Analyze
+on: [pull_request]
+jobs:
+  dart_analyze:
+    if: github.repository_owner == 'theEvilReaper'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+      - name: Generate and analyze the Dart verification corpus
+        run: ./gradlew dartAnalyzeCorpus

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,39 @@ Note that no matter how you contribute, your participation is governed by our
 Fork the project, make a change, and send a pull request!
 
 Make sure you read and follow the instructions in the [pull request template](.github/pull_request_template.md). And
-note
-that all participation in this project (including code submissions) is
+note that all participation in this project (including code submissions) is
 governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Submit bug reports or feature requests
 
 Just use the GitHub issue tracker to submit your bug reports and feature
-requests. 
+requests.
+
+## Running tests
+
+```bash
+./gradlew test
+```
+
+### Dart analyzer verification
+
+DartPoet generates Dart source code, which means a test can pass while still producing invalid Dart code. Comparing the
+generated output against an expected string only verifies the textual representation, not whether the generated code can
+be compiled.
+
+To catch these cases, `./gradlew dartAnalyzeCorpus` collects representative generated snippets and runs `dart analyze`
+on them using a real Dart toolchain. This task requires a Dart SDK available on `PATH` and is intentionally kept
+separate from`test`/`build`/`check`. CI executes this verification for every pull request.
+
+To include generated output from a test in the analyzer corpus:
+
+- `@ParameterizedTest` with the generated spec provided as a method argument, add `@DartAnalyzeCase`. No further changes
+  are required.
+- Plain `@Test` with the spec created as a local variable, replace the usual
+  `assertThat(spec.toString()).isEqualTo(expected)` with
+  `spec.verifyDartOutput(expected)`.
+
+Both annotations and helpers are located in`net.theevilreaper.dartpoet.verify`.
+
+Not every test should be included in the corpus. Only opt in tests whose generated output represents realistic usage
+scenarios.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,12 @@
+# Config for `dart analyze` when it runs over the generated Dart analyzer verification
+# corpus (build/dart-analyze-corpus, see the dartAnalyzeCorpus Gradle task and
+# src/test/kotlin/net/theevilreaper/dartpoet/verify). This is a Kotlin project, not a
+# Dart package - this file exists only because `dart analyze` discovers config by walking
+# up from the analyzed directory, and this repo root is the nearest ancestor.
+analyzer:
+  errors:
+    # Each corpus file is a single, isolated top-level declaration - not real library code
+    # that references it elsewhere. That makes "unused_element" a false positive here
+    # (e.g. a generated private class with nothing else in the file to reference it)
+    # rather than a signal about DartPoet's output.
+    unused_element: ignore

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     compileOnly(libs.jetbrains.annotations)
     testImplementation(libs.google.truth)
     testImplementation(libs.bundles.junit)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(kotlin("test"))
     testRuntimeOnly(libs.junit.engine)
 }
@@ -30,6 +31,22 @@ tasks {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_25)
         }
+    }
+
+    /**
+     * Runs `dart analyze` over the generated corpus in `build/dart-analyze-corpus`.
+     *
+     * The corpus is collected from calls to `verifyDartOutput(expected)` during the
+     * test run (see `DartAnalyzeCorpus.kt`).
+     *
+     * This task is intentionally kept separate from `test`, `build`, and `check`
+     * because it requires a Dart SDK to be available on `PATH`. CI executes it
+     * explicitly after installing the Dart SDK (see `.github/workflows/dart-analyze.yml`).
+     */
+    register<Exec>("dartAnalyzeCorpus") {
+        description = "Runs `dart analyze` over the generated corpus in `build/dart-analyze-corpus`"
+        dependsOn(test)
+        commandLine("dart", "analyze", "build/dart-analyze-corpus")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ dependencyResolutionManagement {
             library("junit.api", "org.junit.jupiter", "junit-jupiter-api").versionRef("junit")
             library("junit.engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
             library("junit.params", "org.junit.jupiter", "junit-jupiter-params").versionRef("junit")
+            library("junit.platform.launcher", "org.junit.platform", "junit-platform-launcher").versionRef("junit")
 
             plugin("changelog", "org.jetbrains.changelog").versionRef("changelog")
             plugin("dokka", "org.jetbrains.dokka").versionRef("dokka")

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/EnumClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/EnumClassTest.kt
@@ -1,6 +1,5 @@
 package net.theevilreaper.dartpoet.classTypes
 
-import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.clazz.ClassSpec
@@ -9,6 +8,7 @@ import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -121,7 +121,7 @@ class EnumClassTest {
                     .build()
             )
             .build()
-        assertThat(enumClass.toString()).isEqualTo(
+        enumClass.verifyDartOutput(
             """
             |enum NavigationEntry {
             |
@@ -184,7 +184,7 @@ class EnumClassTest {
             .endWithNewLine(true)
             .build()
 
-        assertThat(enumClass.toString()).isEqualTo(
+        enumClass.verifyDartOutput(
             """
             |enum Vehicle {
             |

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -49,6 +50,7 @@ class ClassWriterTest {
         )
     }
 
+    @DartAnalyzeCase
     @ParameterizedTest
     @MethodSource("simpleClasses")
     fun `test simple classes`(classSpec: ClassSpec, expected: String) {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
@@ -6,6 +6,7 @@ import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -71,6 +72,7 @@ class ExtensionWriterTest {
         )
     }
 
+    @DartAnalyzeCase
     @ParameterizedTest
     @MethodSource("basicExtensions")
     fun `test basic extension`(extensionSpec: ExtensionSpec, expected: String) {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeCase.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeCase.kt
@@ -1,0 +1,24 @@
+package net.theevilreaper.dartpoet.verify
+
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Marks a `@ParameterizedTest` whose first argument contains generated Dart
+ * output that should be verified by a real Dart toolchain.
+ *
+ * After a successful test invocation, [DartAnalyzeExtension] records the first
+ * argument's `toString()` representation in [DartAnalyzeCorpus].
+ *
+ * This annotation only applies to `@ParameterizedTest` methods, as the generated
+ * output must be provided as a method argument. For regular `@Test` methods, use
+ * [verifyDartOutput] instead.
+ *
+ * @since 1.2.0
+ * @author theEvilReaper
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag("dart-analyze")
+@ExtendWith(DartAnalyzeExtension::class)
+annotation class DartAnalyzeCase

--- a/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeCorpus.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeCorpus.kt
@@ -1,0 +1,40 @@
+package net.theevilreaper.dartpoet.verify
+
+import com.google.common.truth.Truth.assertThat
+import java.util.Collections
+
+/**
+ * Collects a generated Dart source during a test run for later analysis with the Dart toolchain.
+ *
+ * Tests opt in by using [verifyDartOutput]. Once the test plan finishes,
+ * [DartAnalyzeCorpusListener] writes the collected sources to
+ * `build/dart-analyze-corpus`, where they can be validated by the
+ * `dartAnalyzeCorpus` Gradle task.
+ *
+ * @since 1.2.0
+ * @author theEvilReaper
+ */
+internal object DartAnalyzeCorpus {
+
+    private val recorded = Collections.synchronizedList(mutableListOf<String>())
+
+    fun record(dartSource: String) {
+        recorded += dartSource
+    }
+
+    fun snapshot(): List<String> = recorded.toList()
+}
+
+/**
+ * Verifies that this object's generated Dart source matches [expected] and,
+ * if the assertion succeeds, records the output in [DartAnalyzeCorpus].
+ *
+ * Prefer this helper over a plain `assertThat(...).isEqualTo(...)` whenever
+ * the generated output represents valid Dart code that should be included in
+ * the analyzer corpus.
+ */
+internal fun Any.verifyDartOutput(expected: String) {
+    val actual = toString()
+    assertThat(actual).isEqualTo(expected)
+    DartAnalyzeCorpus.record(actual)
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeCorpusListener.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeCorpusListener.kt
@@ -1,0 +1,34 @@
+package net.theevilreaper.dartpoet.verify
+
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestPlan
+import java.io.File
+
+/**
+ * JUnit Platform listener that persists the contents of [DartAnalyzeCorpus] as
+ * individual `.dart` files in `build/dart-analyze-corpus` after the test plan
+ * has finished.
+ *
+ * The listener is discovered automatically via the JUnit Platform `ServiceLoader`
+ * mechanism and runs as part of every test execution. If no test contributed
+ * Dart sources, the output directory is simply left empty.
+ *
+ * The generated files are analyzed by the dedicated `dartAnalyze` task. Analyzer
+ * configuration is picked up automatically from the project's
+ * `analysis_options.yaml`.
+ *
+ * @since 1.2.0
+ * @author theEvilReaper
+ */
+class DartAnalyzeCorpusListener : TestExecutionListener {
+
+    override fun testPlanExecutionFinished(testPlan: TestPlan) {
+        val outputDir = File("build/dart-analyze-corpus")
+        outputDir.deleteRecursively()
+        outputDir.mkdirs()
+
+        DartAnalyzeCorpus.snapshot().forEachIndexed { index, dartSource ->
+            File(outputDir, "case_$index.dart").writeText(dartSource)
+        }
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeExtension.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/verify/DartAnalyzeExtension.kt
@@ -1,0 +1,30 @@
+package net.theevilreaper.dartpoet.verify
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
+import java.lang.reflect.Method
+
+/**
+ * JUnit extension backing [DartAnalyzeCase].
+ *
+ * Executes the intercepted parameterized test invocation and, if it succeeds,
+ * records the first resolved test argument in [DartAnalyzeCorpus]. The argument
+ * is expected to contain the generated Dart source and is stored using its
+ * `toString()` representation.
+ *
+ * @since 1.2.0
+ * @author theEvilReaper
+ */
+class DartAnalyzeExtension : InvocationInterceptor {
+
+    override fun interceptTestTemplateMethod(
+        invocation: InvocationInterceptor.Invocation<Void?>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
+    ) {
+        invocation.proceed()
+        val generated = invocationContext.arguments.firstOrNull() ?: return
+        DartAnalyzeCorpus.record(generated.toString())
+    }
+}

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+net.theevilreaper.dartpoet.verify.DartAnalyzeCorpusListener


### PR DESCRIPTION
## Proposed changes

Adds a verification pipeline that generates real Dart snippets from DartPoet output and  runs `dart analyze` over them, catching invalid generated Dart automatically instead of relying only on hand-written expected-string tests.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)