### PR TITLE
fix(class): reject parameterized class generic declarations

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -313,16 +313,6 @@ class ClassBuilder internal constructor(
 
     /**
      * Add a generic type to the class builder.
-     * @param type the [TypeName] to add
-     * @return the given instance of an [ClassBuilder]
-     */
-    fun generic(type: TypeName) = apply {
-        check(this.classType != ClassType.LIBRARY) { NO_GENERIC_ON_LIBRARIES }
-        this.genericCasts += type
-    }
-
-    /**
-     * Add a generic type to the class builder.
      * @param type the [ClassName] to add
      * @return the given instance of an [ClassBuilder]
      */
@@ -337,7 +327,7 @@ class ClassBuilder internal constructor(
      * @return the given instance of an [ClassBuilder]
      */
     fun generic(type: Type) = apply {
-        generic(type.asTypeName())
+        generic(TypeName.get(type) as ClassName)
     }
 
     /**
@@ -346,7 +336,7 @@ class ClassBuilder internal constructor(
      * @return the given instance of an [ClassBuilder]
      */
     fun generic(type: KClass<*>) = apply {
-        generic(type.asTypeName())
+        generic(type.asClassName())
     }
 
     /**

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
@@ -1,16 +1,17 @@
 package net.theevilreaper.dartpoet.classTypes
 
-import com.google.common.truth.Truth
+import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.clazz.ClassSpec
-import net.theevilreaper.dartpoet.code.buildCodeBlock
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.lang.reflect.Type
 
 @DisplayName("Test the generation of classes which have generic arguments")
 class GenericClassTest {
@@ -23,13 +24,15 @@ class GenericClassTest {
         val positionalParameter = ParameterSpec.positional("element", eClass).build()
         val genericClass: ClassSpec = ClassSpec.builder("TestClass")
             .generic(tClass)
-            .generic(listClass)
+            .generic(eClass)
             .property(
                 PropertySpec.builder("argument", tClass)
+                    .modifier { DartModifier.LATE }
                     .build()
             )
             .property(
                 PropertySpec.builder("list", listClass)
+                    .modifier { DartModifier.LATE }
                     .build()
             )
             .function(
@@ -40,12 +43,12 @@ class GenericClassTest {
                     .build()
             )
             .build()
-        Truth.assertThat(genericClass.toString()).isEqualTo(
+        genericClass.verifyDartOutput(
             """
-            |class TestClass<T, List<E>> {
+            |class TestClass<T, E> {
             |
-            |  T argument;
-            |  List<E> list;
+            |  late T argument;
+            |  late List<E> list;
             |
             |  void add(E element) {
             |    list.add(element);
@@ -53,5 +56,22 @@ class GenericClassTest {
             |}
             """.trimMargin()
         )
+    }
+
+    @Test
+    fun `test generic class with KClass overload`() {
+        val genericClass = ClassSpec.builder("TestClass")
+            .generic(String::class)
+            .build()
+        genericClass.verifyDartOutput("class TestClass<String> {}")
+    }
+
+    @Test
+    fun `test generic class with reflect Type overload`() {
+        val reflectType: Type = String::class.java
+        val genericClass = ClassSpec.builder("TestClass")
+            .generic(reflectType)
+            .build()
+        genericClass.verifyDartOutput("class TestClass<String> {}")
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.dartpoet.classTypes
 
+import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
@@ -8,13 +9,29 @@ import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
 import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.lang.reflect.Type
+import java.util.stream.Stream
 
 @DisplayName("Test the generation of classes which have generic arguments")
 class GenericClassTest {
+
+    companion object {
+        @JvmStatic
+        private fun genericOverloadCases(): Stream<Arguments> {
+            val reflectType: Type = String::class.java
+            return Stream.of(
+                Arguments.of(ClassSpec.builder("TestClass").generic(String::class).build(), "class TestClass<String> {}"),
+                Arguments.of(ClassSpec.builder("TestClass").generic(reflectType).build(), "class TestClass<String> {}"),
+            )
+        }
+    }
 
     @Test
     fun testGenericClassTest() {
@@ -58,20 +75,10 @@ class GenericClassTest {
         )
     }
 
-    @Test
-    fun `test generic class with KClass overload`() {
-        val genericClass = ClassSpec.builder("TestClass")
-            .generic(String::class)
-            .build()
-        genericClass.verifyDartOutput("class TestClass<String> {}")
-    }
-
-    @Test
-    fun `test generic class with reflect Type overload`() {
-        val reflectType: Type = String::class.java
-        val genericClass = ClassSpec.builder("TestClass")
-            .generic(reflectType)
-            .build()
-        genericClass.verifyDartOutput("class TestClass<String> {}")
+    @DartAnalyzeCase
+    @ParameterizedTest
+    @MethodSource("genericOverloadCases")
+    fun `test generic class with KClass and Type overloads`(classSpec: ClassSpec, expected: String) {
+        assertThat(classSpec.toString()).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
## Proposed changes

This pull request fixes an issue where `ClassBuilder.generic()` accepted arbitrary `TypeName` instances, allowing parameterized types such as `List<E>` to be used as declaration-site generic parameters.

Since Dart only allows simple type parameter names in class declarations, this could result in invalid Dart source code being generated.

The implementation now validates generic declarations before generation and rejects unsupported types with a clear exception. The affected tests have also been updated.

Closes #266

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)