### PR TITLE
fix(typedef): stop emitting default parameter values in typedefs

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
@@ -20,7 +20,17 @@ internal class ParameterWriter : Writeable<ParameterSpec>, InitializerAppender<P
      * It should be noted that the writer doesn't check whether the spec contains errors.
      * This would be done when the spec is being created
      */
-    override fun write(spec: ParameterSpec, writer: CodeWriter) {
+    override fun write(spec: ParameterSpec, writer: CodeWriter) = write(spec, writer, writeInitializer = true)
+
+    /**
+     * Writes a [ParameterSpec] to code, optionally suppressing its initializer.
+     * A Dart function type (as used by [net.theevilreaper.dartpoet.function.typedef.function.FunctionTypeDefSpec])
+     * can't declare default parameter values, unlike a real function or constructor declaration.
+     * @param spec the [ParameterSpec] to write
+     * @param writer the [CodeWriter] to write the parameter to
+     * @param writeInitializer whether the parameter's initializer, if present, should be written
+     */
+    fun write(spec: ParameterSpec, writer: CodeWriter, writeInitializer: Boolean) {
         spec.annotations.emitAnnotations(writer, endWithNewLine = false)
 
         if (spec.type == ParameterType.REQUIRED) {
@@ -42,7 +52,10 @@ internal class ParameterWriter : Writeable<ParameterSpec>, InitializerAppender<P
             writer.emit("this.")
         }
         writer.emit(spec.name)
-        writeInitBlock(spec, writer)
+
+        if (writeInitializer) {
+            writeInitBlock(spec, writer)
+        }
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpec.kt
@@ -29,7 +29,14 @@ class FunctionTypeDefSpec(
         val parameterData: ParameterData<ParameterSpec> = ParameterData.of(this)
 
         if (parameterData.hasParameters) {
-            ParameterHelper.writeParameters(parameterData, writer, indent = parameterData.requiredParameters.size > 1)
+            // A Dart function type can't declare default parameter values, those only belong on
+            // the function/constructor that actually implements the signature.
+            ParameterHelper.writeParameters(
+                parameterData,
+                writer,
+                indent = parameterData.requiredParameters.size > 1,
+                writeInitializers = false,
+            )
         }
         writer.emitCode(SEMICOLON)
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -51,9 +51,11 @@ class ParameterSpec internal constructor(
      * writing the parameter details to the specified [CodeWriter].
      *
      * @param codeWriter the [CodeWriter] to which the parameter should be written
+     * @param writeInitializer whether the parameter's initializer, if present, should be written.
+     * Should be `false` in contexts which don't support default parameter values, such as a Dart function type.
      */
-    internal fun write(codeWriter: CodeWriter) {
-        WriterHelper.parameterWriter.write(this, codeWriter)
+    internal fun write(codeWriter: CodeWriter, writeInitializer: Boolean = true) {
+        WriterHelper.parameterWriter.write(this, codeWriter, writeInitializer)
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/ParameterHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/ParameterHelper.kt
@@ -34,35 +34,54 @@ internal object ParameterHelper {
     }
 
     /**
+     * Builds the emit block passed to [emitParameters], honoring [writeInitializers].
+     * Kept as a single factory so every call site shares the same block instead of repeating it.
+     * @param codeWriter the [CodeWriter] the block writes to
+     * @param writeInitializers whether a parameter's initializer, if present, should be written
+     * @return a block which writes a single [ParameterSpec] to [codeWriter]
+     */
+    private fun parameterEmitBlock(codeWriter: CodeWriter, writeInitializers: Boolean): (ParameterSpec) -> Unit =
+        { it.write(codeWriter, writeInitializers) }
+
+    /**
      * Writes each parameter which is part of the [ParameterData] to the given [CodeWriter].
      * @param data the data to write
      * @param codeWriter the writer to append the data
      * @param indent if the generated code should be indented
-     * @param filter    Excluded whether to filter the excluded parameters
+     * @param writeInitializers whether initializers should be written for parameters that have one.
      */
     fun writeParameters(
         data: ParameterData<ParameterSpec>,
         codeWriter: CodeWriter,
         indent: Boolean = false,
+        writeInitializers: Boolean = true,
     ) {
         if (!data.hasParameters) {
             codeWriter.emitEmptyRoundBrackets()
             return
         }
         codeWriter.emit("(")
-        data.positionalParameters.emitParameters(codeWriter, forceNewLines = false)
+        data.positionalParameters.emitParameters(
+            codeWriter,
+            forceNewLines = false,
+            emitBlock = parameterEmitBlock(codeWriter, writeInitializers)
+        )
 
         if (data.positionalParameters.isNotEmpty() && (data.hasAdditionalParameters || data.optionalAndDefault.isNotEmpty())) {
             codeWriter.emit(", ")
         }
 
         if (data.hasAdditionalParameters) {
-            emitRequiredAndNamedParameter(data, codeWriter, indent)
+            emitRequiredAndNamedParameter(data, codeWriter, indent, writeInitializers)
         }
 
         if (data.optionalAndDefault.isNotEmpty()) {
             codeWriter.emit("[")
-            data.optionalAndDefault.emitParameters(codeWriter, forceNewLines = false)
+            data.optionalAndDefault.emitParameters(
+                codeWriter,
+                forceNewLines = false,
+                emitBlock = parameterEmitBlock(codeWriter, writeInitializers)
+            )
             codeWriter.emit("]")
         }
 
@@ -75,11 +94,13 @@ internal object ParameterHelper {
      * @param data the data to write
      * @param codeWriter the writer to append the data
      * @param indent whether to indent the data
+     * @param writeInitializers whether initializers should be written for parameters that have one
      */
     private fun emitRequiredAndNamedParameter(
         data: ParameterData<ParameterSpec>,
         codeWriter: CodeWriter,
         indent: Boolean = false,
+        writeInitializers: Boolean = true,
     ) {
         codeWriter.emit("$CURLY_OPEN")
 
@@ -88,8 +109,13 @@ internal object ParameterHelper {
             codeWriter.indent()
         }
 
-        internalParameterWrite(data.requiredParameters, data.namedParameters.isNotEmpty(), codeWriter)
-        internalParameterWrite(data.namedParameters, codeWriter = codeWriter)
+        internalParameterWrite(
+            data.requiredParameters,
+            data.namedParameters.isNotEmpty(),
+            codeWriter,
+            writeInitializers
+        )
+        internalParameterWrite(data.namedParameters, codeWriter = codeWriter, writeInitializers = writeInitializers)
 
         if (indent) {
             codeWriter.emit(NEW_LINE)
@@ -104,15 +130,21 @@ internal object ParameterHelper {
      * @param parameters the list of parameters to write
      * @param trailingComma whether to emit a trailing comma
      * @param codeWriter the active [CodeWriter]
+     * @param writeInitializers whether initializers should be written for parameters that have one
      */
     private fun internalParameterWrite(
         parameters: List<ParameterSpec>,
         trailingComma: Boolean = false,
-        codeWriter: CodeWriter
+        codeWriter: CodeWriter,
+        writeInitializers: Boolean = true,
     ) {
         if (parameters.isEmpty()) return
 
-        parameters.emitParameters(codeWriter, forceNewLines = false)
+        parameters.emitParameters(
+            codeWriter,
+            forceNewLines = false,
+            emitBlock = parameterEmitBlock(codeWriter, writeInitializers)
+        )
         if (trailingComma) {
             codeWriter.emit(COMMA_SEPARATOR)
         }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
@@ -1,6 +1,9 @@
 package net.theevilreaper.dartpoet.code.writer
 
 import com.google.common.truth.Truth
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
 import net.theevilreaper.dartpoet.function.typedef.TypeDef
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
@@ -9,6 +12,7 @@ import net.theevilreaper.dartpoet.type.DYNAMIC
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
 import net.theevilreaper.dartpoet.type.asTypeName
 import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -91,7 +95,7 @@ class TypeDefWriterTest {
                             .build()
                     )
                     .build(),
-                "typedef ValueUpdate<E> = E Function(String value, [E? data = null]);"
+                "typedef ValueUpdate<E> = E Function(String value, [E? data]);"
             ),
             Arguments.of(
                 TypeDef.function("ValueUpdate", genericClassName)
@@ -105,7 +109,7 @@ class TypeDefWriterTest {
                             .build()
                     )
                     .build(),
-                "typedef ValueUpdate<E> = E Function(Map<String, int> map, [E? data = null]);"
+                "typedef ValueUpdate<E> = E Function(Map<String, int> map, [E? data]);"
             ),
             Arguments.of(
                 TypeDef.function("ValueUpdate", genericClassName)
@@ -132,7 +136,7 @@ class TypeDefWriterTest {
                             .build() // Named optional weil nullable oder default
                     )
                     .build(),
-                "typedef ValueUpdate<E> = E Function(E data, {required String b, String? a, int c = 10});"
+                "typedef ValueUpdate<E> = E Function(E data, {required String b, String? a, int c});"
             )
         )
     }
@@ -151,10 +155,59 @@ class TypeDefWriterTest {
         Truth.assertThat(typeDef.toString()).isEqualTo(expected)
     }
 
+    @DartAnalyzeCase
     @ParameterizedTest
     @MethodSource("differentParameterTypes")
     fun `test typedef write with different parameter types`(typeDef: AbstractTypeDef<*>, expected: String) {
         Truth.assertThat(typeDef.toString()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `test typedef and its implementing function in the same file`() {
+        val file = DartFile.builder("callback_lib")
+            .type(
+                ClassSpec.anonymousClassBuilder()
+                    .typedef(
+                        TypeDef.function("Callback")
+                            .parameters(
+                                ParameterSpec.positional("message", String::class).build(),
+                                ParameterSpec.optional("code", Int::class).nullable(true).build()
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .type(
+                ClassSpec.builder("Handler")
+                    .function(
+                        FunctionSpec.builder("onMessage")
+                            .returns(Void::class)
+                            .parameters(
+                                ParameterSpec.positional("message", String::class).build(),
+                                ParameterSpec.optional("code", Int::class)
+                                    .nullable(true)
+                                    .initializer("%L", "0")
+                                    .build()
+                            )
+                            .addCode("code ??= 0;")
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+        file.verifyDartOutput(
+            """
+            |typedef Callback = void Function(String message, [int? code]);
+            |
+            |class Handler {
+            |
+            |  void onMessage(String message, [int? code = 0]) {
+            |    code ??= 0;
+            |  }
+            |}
+            |
+            """.trimMargin()
+        )
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Function typedefs incorrectly emitted default parameter values. Dart only allows defaults on the implementing function not on the type itself. Typedef output is now corrected and verified against the real Dart analyzer.  

Closes #265

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)