### PR TITLE
feat(parameter): support super.fieldName parameters

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ParameterWriter.kt
@@ -49,7 +49,7 @@ internal class ParameterWriter : Writeable<ParameterSpec>, InitializerAppender<P
         val emitNullable = if (spec.isNullable && spec.typeName != null) "?·" else if (spec.typeName != null) "·" else EMPTY_STRING
         writer.emit(emitNullable)
         if (spec.hasNoTypeName) {
-            writer.emit("this.")
+            writer.emit(if (spec.isSuperParameter) "super." else "this.")
         }
         writer.emit(spec.name)
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterBuilder.kt
@@ -28,6 +28,7 @@ class ParameterBuilder internal constructor(
     internal var named: Boolean = false
     internal var nullable: Boolean = false
     internal var coVariant: Boolean = false
+    internal var isSuperParameter: Boolean = false
     internal var initializer: CodeBlock? = null
 
     /**
@@ -65,6 +66,16 @@ class ParameterBuilder internal constructor(
      */
     fun coVariant(coVariant: Boolean) = apply {
         this.coVariant = coVariant
+    }
+
+    /**
+     * Marks the parameter as a Dart super-initializer parameter (`super.fieldName`),
+     * forwarding it directly to the superclass constructor.
+     * @param superParameter true if the parameter should be written as `super.fieldName`
+     * @return the current [ParameterBuilder] instance
+     */
+    fun superParameter(superParameter: Boolean = true) = apply {
+        this.isSuperParameter = superParameter
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpec.kt
@@ -35,6 +35,7 @@ class ParameterSpec internal constructor(
     internal val initializer = builder.initializer
     internal val annotations = builder.annotationData.annotations.toImmutableSet()
     internal val coVariant = builder.coVariant
+    internal val isSuperParameter = builder.isSuperParameter
     override val hasInitializer = initializer != null && initializer.isNotEmpty()
     internal val hasNoTypeName: Boolean = builder.typeName == null
 
@@ -44,6 +45,7 @@ class ParameterSpec internal constructor(
      */
     init {
         check(name.trim().isNotEmpty()) { "The name of a parameter can't be empty" }
+        check(!isSuperParameter || typeName == null) { "A super parameter can't have an explicit typeName" }
     }
 
     /**
@@ -72,6 +74,7 @@ class ParameterSpec internal constructor(
         val builder = ParameterBuilder(this.name, this.type, this.typeName)
         builder.named = isNamed
         builder.nullable = isNullable
+        builder.superParameter(isSuperParameter)
         builder.annotations(*this.annotations.toTypedArray())
         builder.initializer = initializer
         return builder

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/LibraryCorpusTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/LibraryCorpusTest.kt
@@ -5,6 +5,7 @@ import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -53,6 +54,61 @@ class LibraryCorpusTest {
             |  int y;
             |
             |  Point(this.x, this.y);
+            |
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test subclass constructor with super parameter renders and analyzes cleanly`() {
+        val file = DartFile.builder("shape_lib")
+            .type(
+                ClassSpec.builder("Shape")
+                    .properties(
+                        PropertySpec.builder("id", Int::class).build(),
+                    )
+                    .constructor(
+                        ConstructorSpec.builder("Shape")
+                            .parameters(
+                                ParameterSpec.positional("id").build(),
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .type(
+                ClassSpec.builder("Circle")
+                    .superClass(ClassName("Shape"))
+                    .properties(
+                        PropertySpec.builder("radius", Double::class).build(),
+                    )
+                    .constructor(
+                        ConstructorSpec.builder("Circle")
+                            .parameters(
+                                ParameterSpec.positional("id").superParameter().build(),
+                                ParameterSpec.positional("radius").build(),
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+        file.verifyDartOutput(
+            """
+            |class Shape {
+            |
+            |  int id;
+            |
+            |  Shape(this.id);
+            |
+            |}
+            |class Circle extends Shape {
+            |
+            |  double radius;
+            |
+            |  Circle(super.id, this.radius);
             |
             |}
             |

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ConstructorWriterTest.kt
@@ -128,4 +128,19 @@ class ConstructorWriterTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun `test constructor with super and field initializing parameters`() {
+        val constructor = ConstructorSpec.builder("Cat")
+            .parameters(
+                ParameterSpec.required("name").superParameter().build(),
+                ParameterSpec.named("color").nullable(true).build(),
+            )
+            .build()
+        assertThat(constructor.toString()).isEqualTo(
+            """
+            Cat({required super.name, this.color});
+            """.trimIndent()
+        )
+    }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterSpecTest.kt
@@ -4,6 +4,7 @@ import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -30,7 +31,15 @@ class ParameterSpecTest {
                 {
                     ParameterSpec.named("name", String::class).initializer("%C", "theEvilReaper")
                 },
-            )
+            ),
+            Arguments.of(
+                "super.name",
+                { ParameterSpec.positional("name").superParameter() },
+            ),
+            Arguments.of(
+                "required super.name",
+                { ParameterSpec.required("name").superParameter() },
+            ),
         )
     }
 
@@ -56,5 +65,20 @@ class ParameterSpecTest {
         assertEquals(parameterSpec.isNullable, specAsBuilder.nullable)
         assertTrue { specAsBuilder.initializer!!.isNotEmpty() }
         assertContentEquals(parameterSpec.annotations, specAsBuilder.annotationData.annotations)
+    }
+
+    @Test
+    fun `test super parameter with explicit typeName throws exception`() {
+        val exception = assertThrows<IllegalStateException> {
+            ParameterSpec.positional("name", String::class).superParameter().build()
+        }
+        assertTrue(exception.message?.contains("super parameter") == true)
+    }
+
+    @Test
+    fun `test super parameter spec to builder conversion`() {
+        val parameterSpec = ParameterSpec.positional("name").superParameter().build()
+        val specAsBuilder = parameterSpec.toBuilder()
+        assertTrue(specAsBuilder.isSuperParameter)
     }
 }


### PR DESCRIPTION
## Proposed changes

Adds support for Dart's super-initializer parameters, letting a constructor parameter forward directly to the superclass instead of only initializing its own field.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)