### PR TITLE
feat(type): add FunctionTypeName for inline Dart function types

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/function/FunctionTypeName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/function/FunctionTypeName.kt
@@ -1,0 +1,84 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.parameter.ParameterChecker
+import net.theevilreaper.dartpoet.parameter.ParameterContext
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.util.EMPTY_STRING
+import net.theevilreaper.dartpoet.util.NULLABLE_CHAR
+import net.theevilreaper.dartpoet.util.ParameterHelper
+import net.theevilreaper.dartpoet.util.parameter.ParameterData
+import net.theevilreaper.dartpoet.function.typedef.function.FunctionTypeDefSpec
+
+/**
+ * Represents an anonymous, inline Dart function type such as `void Function(int count)?`.
+ *
+ * Unlike [FunctionTypeDefSpec], this type has no
+ * name of its own and can be used anywhere a [TypeName] is accepted (property types, parameter types,
+ * return types, generic type arguments).
+ *
+ * @param returnType the return type of the function type
+ * @param parameters the parameters of the function type
+ * @param isNullable whether the function type itself can be null (default is false)
+ * @since 2.1.0
+ * @author theEvilReaper
+ */
+class FunctionTypeName internal constructor(
+    val returnType: TypeName,
+    parameters: List<ParameterSpec>,
+    isNullable: Boolean = false
+) : TypeName(isNullable), ParameterContext<ParameterSpec> by ParameterContext(parameters) {
+
+    init {
+        ParameterChecker.checkOptionalParameters(parametersWithDefaults)
+    }
+
+    /**
+     * Emits `returnType Function(params)` (optionally suffixed with `?`) to the given [CodeWriter].
+     */
+    override fun emit(out: CodeWriter): CodeWriter {
+        out.emitCode("%T", returnType)
+        out.emitSpace()
+        out.emitCode("%T", Function::class.asTypeName())
+
+        val parameterData = ParameterData.of(this)
+        if (parameterData.hasParameters) {
+            ParameterHelper.writeParameters(
+                parameterData,
+                out,
+                indent = parameterData.requiredParameters.size > 1,
+                writeInitializers = false,
+            )
+        } else {
+            out.emitEmptyRoundBrackets()
+        }
+
+        if (isNullable) {
+            out.emit(NULLABLE_CHAR)
+        }
+        return out
+    }
+
+    /**
+     * Creates a copy of this [FunctionTypeName] with the given nullable flag.
+     * @param nullable the nullable flag to set
+     * @return a new [FunctionTypeName] instance with the provided nullable flag
+     */
+    override fun copy(nullable: Boolean): FunctionTypeName = FunctionTypeName(returnType, parameters, nullable)
+
+    /**
+     * Function types are never used as a generic self-reference target (see [ExtensionSpec][net.theevilreaper.dartpoet.extension.ExtensionSpec]),
+     * so there is no meaningful raw data to expose.
+     */
+    override fun getRawData(): String = EMPTY_STRING
+
+    companion object {
+
+        /**
+         * Creates a new [FunctionTypeNameBuilder] instance.
+         * @return the created builder
+         */
+        @JvmStatic
+        fun builder() = FunctionTypeNameBuilder()
+    }
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/function/FunctionTypeNameBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/function/FunctionTypeNameBuilder.kt
@@ -1,0 +1,76 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import kotlin.reflect.KClass
+
+/**
+ * Builder for [FunctionTypeName]. Entered via [FunctionTypeName.builder].
+ * @since 2.1.0
+ * @author theEvilReaper
+ */
+class FunctionTypeNameBuilder internal constructor() {
+
+    private var returnType: TypeName = Void::class.asTypeName()
+    private val parameters: MutableList<ParameterSpec> = mutableListOf()
+    private var nullable: Boolean = false
+
+    /**
+     * Sets the return type of the function type.
+     * @param typeName the return type as a [TypeName]
+     * @return the current instance of [FunctionTypeNameBuilder]
+     */
+    fun returns(typeName: TypeName) = apply {
+        this.returnType = typeName
+    }
+
+    /**
+     * Sets the return type of the function type.
+     * @param typeName the return type as a [ClassName]
+     * @return the current instance of [FunctionTypeNameBuilder]
+     */
+    fun returns(typeName: ClassName) = apply {
+        this.returnType = typeName
+    }
+
+    /**
+     * Sets the return type of the function type.
+     * @param typeName the return type as a [KClass]
+     * @return the current instance of [FunctionTypeNameBuilder]
+     */
+    fun returns(typeName: KClass<*>) = apply {
+        this.returnType = typeName.asTypeName()
+    }
+
+    /**
+     * Adds a parameter to the list of parameters.
+     * @param parameterSpec the parameter specification
+     * @return the current instance of [FunctionTypeNameBuilder]
+     */
+    fun parameter(parameterSpec: ParameterSpec) = apply {
+        this.parameters += parameterSpec
+    }
+
+    /**
+     * Adds multiple parameters to the list of parameters.
+     * @param parameterSpecs the parameter specifications
+     * @return the current instance of [FunctionTypeNameBuilder]
+     */
+    fun parameters(vararg parameterSpecs: ParameterSpec) = apply {
+        this.parameters += parameterSpecs
+    }
+
+    /**
+     * Sets whether the function type itself is nullable.
+     * @param nullable whether the function type can be null (default is true)
+     * @return the current instance of [FunctionTypeNameBuilder]
+     */
+    fun nullable(nullable: Boolean = true) = apply {
+        this.nullable = nullable
+    }
+
+    /**
+     * Creates a new [FunctionTypeName] using the settings defined in this builder.
+     * @return the created [FunctionTypeName] instance
+     */
+    fun build(): FunctionTypeName = FunctionTypeName(returnType, parameters, nullable)
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -9,6 +9,9 @@ import net.theevilreaper.dartpoet.function.FunctionType
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.MethodAccessorType
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.FunctionTypeName
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.STRING
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.DYNAMIC
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
@@ -250,6 +253,29 @@ class FunctionWriterTest {
             """
            abstract void testMethod({required String b, String? a, int c = 10});
             """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `test function write with function type parameter`() {
+        val functionSpec = FunctionSpec.builder("doWork")
+            .parameter(
+                ParameterSpec.positional(
+                    "mapper",
+                    FunctionTypeName.builder()
+                        .returns(INTEGER)
+                        .parameter(ParameterSpec.positional("value", STRING).build())
+                        .build()
+                ).build()
+            )
+            .addCode("mapper('test');")
+            .build()
+        functionSpec.verifyDartOutput(
+            """
+            |void doWork(int Function(String value) mapper) {
+            |  mapper('test');
+            |}
+            """.trimMargin()
         )
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/PropertyWriterTest.kt
@@ -4,8 +4,13 @@ import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.FunctionTypeName
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.STRING
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.type.asTypeName
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -146,5 +151,35 @@ class PropertyWriterTest {
         assertNotNull(property)
         assertTrue(property.nullable)
         assertThat(property.toString()).isEqualTo("String? name;")
+    }
+
+    @Test
+    fun `write non-nullable empty function type property`() {
+        val property = PropertySpec.builder("callback", FunctionTypeName.builder().build())
+            .modifier { DartModifier.LATE }
+            .build()
+        property.verifyDartOutput("late void Function() callback;")
+    }
+
+    @Test
+    fun `write nullable function type property`() {
+        val property = PropertySpec.builder("onDone", FunctionTypeName.builder().nullable().build())
+            .build()
+        property.verifyDartOutput("void Function()? onDone;")
+    }
+
+    @Test
+    fun `write property with nested function type parameter`() {
+        val innerFunctionType = FunctionTypeName.builder()
+            .returns(INTEGER)
+            .parameter(ParameterSpec.positional("value", STRING).build())
+            .build()
+        val outerFunctionType = FunctionTypeName.builder()
+            .parameter(ParameterSpec.positional("mapper", innerFunctionType).build())
+            .build()
+        val property = PropertySpec.builder("onMap", outerFunctionType)
+            .modifier { DartModifier.LATE }
+            .build()
+        property.verifyDartOutput("late void Function(int Function(String value) mapper) onMap;")
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/type/FunctionTypeNameTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/type/FunctionTypeNameTest.kt
@@ -1,0 +1,127 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@DisplayName("Test cases for the FunctionTypeName implementation")
+class FunctionTypeNameTest {
+
+    companion object {
+
+        @JvmStatic
+        private fun functionTypeNames() = Stream.of(
+            Arguments.of(
+                "void Function()",
+                FunctionTypeName.builder().build()
+            ),
+            Arguments.of(
+                "int Function(String value)",
+                FunctionTypeName.builder()
+                    .returns(INTEGER)
+                    .parameter(ParameterSpec.positional("value", STRING).build())
+                    .build()
+            ),
+            Arguments.of(
+                "void Function(int a, int b)",
+                FunctionTypeName.builder()
+                    .parameters(
+                        ParameterSpec.positional("a", INTEGER).build(),
+                        ParameterSpec.positional("b", INTEGER).build()
+                    )
+                    .build()
+            ),
+            Arguments.of(
+                "String Function()",
+                FunctionTypeName.builder().returns(String::class).build()
+            ),
+            Arguments.of(
+                "MyType Function()",
+                FunctionTypeName.builder().returns(ClassName("MyType")).build()
+            ),
+            Arguments.of(
+                "T Function(T value)",
+                FunctionTypeName.builder()
+                    .returns(ClassName("T"))
+                    .parameter(ParameterSpec.positional("value", ClassName("T")).build())
+                    .build()
+            ),
+        )
+    }
+
+    @ParameterizedTest(name = "Test creation of: {0}")
+    @MethodSource("functionTypeNames")
+    fun `test function type name write`(expected: String, functionType: FunctionTypeName) {
+        assertEquals(expected, functionType.toString())
+    }
+
+    @Test
+    fun `test nullable function type through property writer`() {
+        val property = PropertySpec.builder(
+            "onDone",
+            FunctionTypeName.builder().nullable().build()
+        ).build()
+        assertEquals("void Function()? onDone;", property.toString())
+    }
+
+    @Test
+    fun `test nullable function type with parameters through property writer`() {
+        val property = PropertySpec.builder(
+            "onComplete",
+            FunctionTypeName.builder()
+                .returns(INTEGER)
+                .parameter(ParameterSpec.positional("value", STRING).build())
+                .nullable()
+                .build()
+        ).build()
+        assertEquals("int Function(String value)? onComplete;", property.toString())
+    }
+
+    @Test
+    fun `test equals and hashCode for function type name`() {
+        val first = FunctionTypeName.builder()
+            .returns(INTEGER)
+            .parameter(ParameterSpec.positional("value", STRING).build())
+            .build()
+        val second = FunctionTypeName.builder()
+            .returns(INTEGER)
+            .parameter(ParameterSpec.positional("value", STRING).build())
+            .build()
+        val third = FunctionTypeName.builder()
+            .returns(STRING)
+            .parameter(ParameterSpec.positional("value", STRING).build())
+            .build()
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test copy method from the function type name`() {
+        val functionType = FunctionTypeName.builder().returns(INTEGER).build()
+        assertFalse { functionType.isNullable }
+        val nullableType = functionType.copy(nullable = true)
+        assertTrue { nullableType.isNullable }
+        // Verify through property writer (the real code generation path)
+        val property = PropertySpec.builder("fn", nullableType).build()
+        assertEquals("int Function()? fn;", property.toString())
+    }
+
+    @Test
+    fun `test builder throws for invalid optional parameter`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            FunctionTypeName.builder()
+                .parameter(ParameterSpec.optional("value", INTEGER).build())
+                .build()
+        }
+        assertEquals("Optional parameters must be nullable or have an initializer", exception.message)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds FunctionTypeName so inline Dart function types (e.g. `void Function(int count)?`) can be generated as a proper type usable as property, parameter, or return types instead of needing manual string workarounds. Rounds out DartPoet's type system alongside existing types like ParameterizedTypeName. Covered by unit tests and verified against the real Dart analyzer via the existing corpus check.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)