### PR TITLE
fix(type): doubled nullable marker on generic type arguments

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/ParameterizedTypeName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/ParameterizedTypeName.kt
@@ -1,6 +1,7 @@
 package net.theevilreaper.dartpoet.type
 
 import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import net.theevilreaper.dartpoet.util.GREATER_THAN_SIGN
@@ -77,12 +78,16 @@ class ParameterizedTypeName internal constructor(
         }
 
         if (typeArguments.isNotEmpty()) {
+            // Dispatch each argument through emit() (like %T does), not toString(): TypeName.toString()
+            // goes through cachedString, which appends a nullable "?" on top of whatever emit() already
+            // wrote, doubling it for any TypeName whose own emit() self-appends "?" (e.g. ClassName,
+            // FunctionTypeName).
             val joinedArguments = StringHelper.concatData(
                 typeArguments,
                 prefix = LESS_THAN_SIGN,
                 separator = COMMA_SEPARATOR,
                 postfix = GREATER_THAN_SIGN
-            ) { it.toString() }
+            ) { buildCodeString { it.emit(this) } }
             out.emit(joinedArguments)
         }
         return out

--- a/src/test/kotlin/net/theevilreaper/dartpoet/type/ParameterizedTypeNameTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/type/ParameterizedTypeNameTest.kt
@@ -24,6 +24,14 @@ class ParameterizedTypeNameTest {
             Arguments.of(
                 "Map<String, dynamic>",
                 Map::class.parameterizedBy(String::class.asTypeName(), DYNAMIC)
+            ),
+            Arguments.of(
+                "List<String?>",
+                List::class.parameterizedBy(String::class.asTypeName().copy(nullable = true))
+            ),
+            Arguments.of(
+                "Map<String, int?>",
+                Map::class.parameterizedBy(String::class.asTypeName(), Int::class.asTypeName().copy(nullable = true))
             )
         )
 


### PR DESCRIPTION
## Proposed changes

Nullable type arguments used inside a generic type (e.g. String? in List<...>) rendered with a doubled ? (List<String??>) instead of a single one. Root cause was an inconsistent code path for nullable-marker emission between type arguments and the rest of the type system.                                                                                                                                     
                                                                
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)