### PR TITLE
feat(type): support bounded generic type parameters

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -14,6 +14,7 @@ import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.type.asClassName
 import net.theevilreaper.dartpoet.type.asTypeName
 import net.theevilreaper.dartpoet.util.NO_GENERIC_ON_LIBRARIES
@@ -356,6 +357,33 @@ class ClassBuilder internal constructor(
     fun generic(type: Class<*>) = apply {
         generic(type.asClassName())
     }
+
+    /**
+     * Add a bounded generic type parameter to the class builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [TypeName]
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun generic(name: String, bound: TypeName) = apply {
+        checkNotLibrary(NO_GENERIC_ON_LIBRARIES)
+        this.genericCasts += TypeVariableName(name, bound)
+    }
+
+    /**
+     * Add a bounded generic type parameter to the class builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [ClassName]
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
+
+    /**
+     * Add a bounded generic type parameter to the class builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [KClass]
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
 
     /**
      * Creates a new instance from the [ClassSpec].

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -8,6 +8,7 @@ import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.code.emitConstructors
 import net.theevilreaper.dartpoet.code.emitFunctions
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.util.*
 import net.theevilreaper.dartpoet.util.CURLY_CLOSE
 import net.theevilreaper.dartpoet.util.CURLY_OPEN
@@ -151,7 +152,7 @@ internal class ClassWriter : Writeable<ClassSpec> {
                     prefix = LESS_THAN_SIGN,
                     separator = COMMA_SEPARATOR,
                     postfix = GREATER_THAN_SIGN
-                ) { it.toString() }
+                ) { TypeVariableName.renderDeclaration(it) }
                 writer.emitCode("%L", joinedGenerics)
                 writer.emitSpace()
             }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriter.kt
@@ -34,7 +34,7 @@ internal class ExtensionWriter : Writeable<ExtensionSpec>, DocumentationAppender
         }
 
         if (spec.hasGenericCast) {
-            writer.emitGenericBlock("%L", spec.joinedRawTypes)
+            writer.emitGenericBlock("%L", spec.genericDeclaration)
         }
 
         writer.emitCode("·%L·%T·", ON.identifier, spec.extClass)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionBuilder.kt
@@ -4,6 +4,7 @@ import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.type.asTypeName
 import kotlin.reflect.KClass
 
@@ -105,6 +106,32 @@ class ExtensionBuilder(
     fun genericTypes(vararg genericType: KClass<*>) = apply {
         this.genericTypes += genericType.map { it.asTypeName() }
     }
+
+    /**
+     * Add a bounded generic type parameter for the extension, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [TypeName]
+     * @return the current builder instance
+     */
+    fun genericTypes(name: String, bound: TypeName) = apply {
+        this.genericTypes += TypeVariableName(name, bound)
+    }
+
+    /**
+     * Add a bounded generic type parameter for the extension, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [ClassName]
+     * @return the current builder instance
+     */
+    fun genericTypes(name: String, bound: ClassName) = genericTypes(name, bound as TypeName)
+
+    /**
+     * Add a bounded generic type parameter for the extension, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [KClass]
+     * @return the current builder instance
+     */
+    fun genericTypes(name: String, bound: KClass<*>) = genericTypes(name, bound.asTypeName())
 
     /**
      * Creates a new instance from the [ExtensionSpec] class.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
@@ -9,6 +9,7 @@ import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.parameter.ParameterBuilder
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.type.asTypeName
 import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
@@ -44,6 +45,18 @@ class ExtensionSpec internal constructor(
             false -> EMPTY_STRING
         }
         genericType.joinToString(separator) { it.getRawData() }
+    }
+
+    /**
+     * The generic-declaration form of [genericType], including bounds where present (via
+     * [net.theevilreaper.dartpoet.type.TypeVariableName.renderDeclaration]),
+     * used only for the `<...>` output in [ExtensionWriter]. Unlike
+     * [joinedRawTypes] (bare names only, used by the validation in the `init` block below), this
+     * must never be used for anything that compares against [extClass]'s raw data.
+     */
+    internal val genericDeclaration by lazy {
+        if (genericType.isEmpty()) return@lazy EMPTY_STRING
+        genericType.joinToString(COMMA_SEPARATOR) { TypeVariableName.renderDeclaration(it) }
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/TypeVariableName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/TypeVariableName.kt
@@ -1,0 +1,69 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.buildCodeString
+import net.theevilreaper.dartpoet.util.NULLABLE_CHAR
+
+/**
+ * Represents a generic type parameter, optionally bounded, such as `T` or `T extends Comparable`.
+ *
+ * [emit] writes only the bare name — never the bound. A type parameter is referenced as a plain
+ * type everywhere else in a class/extension body (property types, parameter types, return types),
+ * and `T extends Bar` would be invalid Dart in any of those positions. The bound is rendered only
+ * by [renderDeclaration], called exclusively by the writers that emit a generic *declaration*
+ * (as opposed to a type *reference*): `ClassWriter.writeGenericArguments` and
+ * `ExtensionSpec.genericDeclaration`.
+ *
+ * @param name the name of the type parameter
+ * @param bound the optional bound of the type parameter (Dart has no multi-bound syntax, so this
+ *              is a single [TypeName], not a list)
+ * @param isNullable whether this type name can be null (default is false)
+ * @since 2.1.0
+ * @author theEvilReaper
+ */
+class TypeVariableName internal constructor(
+    val name: String,
+    val bound: TypeName? = null,
+    isNullable: Boolean = false
+) : TypeName(isNullable) {
+
+    init {
+        require(name.trim().isNotEmpty()) { "The name of a TypeVariableName can't be empty" }
+    }
+
+    /**
+     * Emits only the bare [name] of this type parameter — never [bound]. See the class KDoc for why.
+     */
+    override fun emit(out: CodeWriter): CodeWriter {
+        out.emit(name)
+        if (isNullable) {
+            out.emit(NULLABLE_CHAR)
+        }
+        return out
+    }
+
+    override fun copy(nullable: Boolean): TypeVariableName = TypeVariableName(name, bound, nullable)
+
+    override fun getRawData(): String = name
+
+    companion object {
+
+        /**
+         * Renders [typeName] as it should appear at a generic-declaration site: the bare name,
+         * plus ` extends <bound>` if [typeName] is a [TypeVariableName] with a non-null [bound].
+         * Not for general type references — only for declaration sites.
+         *
+         * Builds each piece via [buildCodeString] + [TypeName.emit] rather than [TypeName.toString],
+         * so a nullable bound doesn't double its `?` (toString() goes through `cachedString`, which
+         * re-appends `?` on top of whatever `emit()` already wrote).
+         *
+         * @param typeName the type name to render as a declaration
+         * @return the rendered declaration string
+         */
+        internal fun renderDeclaration(typeName: TypeName): String {
+            val name = buildCodeString { typeName.emit(this) }
+            val bound = (typeName as? TypeVariableName)?.bound ?: return name
+            return "$name extends ${buildCodeString { bound.emit(this) }}"
+        }
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
@@ -31,6 +31,31 @@ class GenericClassTest {
                 Arguments.of(ClassSpec.builder("TestClass").generic(reflectType).build(), "class TestClass<String> {}"),
             )
         }
+
+        @JvmStatic
+        private fun boundedGenericCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                ClassSpec.builder("Box").generic("T", ClassName("Comparable")).build(),
+                "class Box<T extends Comparable> {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Box")
+                    .generic("T", ClassName("Comparable").parameterizedBy(ClassName("T")))
+                    .build(),
+                "class Box<T extends Comparable<T>> {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Box").generic("T", String::class).build(),
+                "class Box<T extends String> {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Box")
+                    .generic("T", ClassName("Comparable"))
+                    .generic(ClassName("E"))
+                    .build(),
+                "class Box<T extends Comparable, E> {}"
+            ),
+        )
     }
 
     @Test
@@ -79,6 +104,13 @@ class GenericClassTest {
     @ParameterizedTest
     @MethodSource("genericOverloadCases")
     fun `test generic class with KClass and Type overloads`(classSpec: ClassSpec, expected: String) {
+        assertThat(classSpec.toString()).isEqualTo(expected)
+    }
+
+    @DartAnalyzeCase
+    @ParameterizedTest
+    @MethodSource("boundedGenericCases")
+    fun `test generic class with bounded type parameter`(classSpec: ClassSpec, expected: String) {
         assertThat(classSpec.toString()).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
@@ -70,6 +70,29 @@ class ExtensionWriterTest {
                 "extension MapExt<T, E> on Map<T, E> {}"
             ),
         )
+
+        @JvmStatic
+        private fun boundedGenericExtension() = Stream.of(
+            Arguments.of(
+                ExtensionSpec.builder("ListExt", List::class.parameterizedBy(ClassName("T")))
+                    .genericTypes("T", ClassName("Comparable"))
+                    .build(),
+                "extension ListExt<T extends Comparable> on List<T> {}"
+            ),
+            Arguments.of(
+                ExtensionSpec.builder("ListExt", List::class.parameterizedBy(ClassName("T")))
+                    .genericTypes("T", String::class)
+                    .build(),
+                "extension ListExt<T extends String> on List<T> {}"
+            ),
+            Arguments.of(
+                ExtensionSpec.builder("MapExt", Map::class.parameterizedBy(ClassName("T"), ClassName("E")))
+                    .genericTypes("T", ClassName("Comparable"))
+                    .genericTypes(ClassName("E"))
+                    .build(),
+                "extension MapExt<T extends Comparable, E> on Map<T, E> {}"
+            ),
+        )
     }
 
     @DartAnalyzeCase
@@ -88,6 +111,13 @@ class ExtensionWriterTest {
     @ParameterizedTest
     @MethodSource("basicGenericExtension")
     fun `test generic extension`(extensionSpec: ExtensionSpec, expected: String) {
+        assertThat(extensionSpec.toString()).isEqualTo(expected)
+    }
+
+    @DartAnalyzeCase
+    @ParameterizedTest
+    @MethodSource("boundedGenericExtension")
+    fun `test bounded generic extension`(extensionSpec: ExtensionSpec, expected: String) {
         assertThat(extensionSpec.toString()).isEqualTo(expected)
     }
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/type/TypeVariableNameTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/type/TypeVariableNameTest.kt
@@ -1,0 +1,81 @@
+package net.theevilreaper.dartpoet.type
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("Test cases for the TypeVariableName implementation")
+class TypeVariableNameTest {
+
+    @Test
+    fun `test emit without bound`() {
+        val typeVariable = TypeVariableName("T")
+        assertEquals("T", typeVariable.toString())
+    }
+
+    @Test
+    fun `test emit never includes the bound`() {
+        val typeVariable = TypeVariableName("T", ClassName("Comparable"))
+        assertEquals("T", typeVariable.toString())
+    }
+
+    @Test
+    fun `test renderDeclaration without bound`() {
+        val typeVariable = TypeVariableName("T")
+        assertEquals("T", TypeVariableName.renderDeclaration(typeVariable))
+    }
+
+    @Test
+    fun `test renderDeclaration with bound`() {
+        val typeVariable = TypeVariableName("T", ClassName("Comparable"))
+        assertEquals("T extends Comparable", TypeVariableName.renderDeclaration(typeVariable))
+    }
+
+    @Test
+    fun `test renderDeclaration with nullable bound does not double the marker`() {
+        val typeVariable = TypeVariableName("T", ClassName("Comparable").copy(nullable = true))
+        assertEquals("T extends Comparable?", TypeVariableName.renderDeclaration(typeVariable))
+    }
+
+    @Test
+    fun `test renderDeclaration falls back to bare emit for a non-TypeVariableName`() {
+        val plain = ClassName("E")
+        assertEquals("E", TypeVariableName.renderDeclaration(plain))
+    }
+
+    @Test
+    fun `test copy preserves the bound`() {
+        val bound = ClassName("Comparable")
+        val typeVariable = TypeVariableName("T", bound)
+        val copied = typeVariable.copy(nullable = true)
+        assertTrue { copied.isNullable }
+        assertEquals(bound, copied.bound)
+    }
+
+    @Test
+    fun `test getRawData returns the bare name`() {
+        val typeVariable = TypeVariableName("T", ClassName("Comparable"))
+        assertEquals("T", typeVariable.getRawData())
+    }
+
+    @Test
+    fun `test empty name throws`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            TypeVariableName("   ")
+        }
+        assertEquals("The name of a TypeVariableName can't be empty", exception.message)
+    }
+
+    @Test
+    fun `test two TypeVariableName with the same name but different bounds are equal`() {
+        // Intentional: equality is based on emit() output (bare name only, per cachedString),
+        // not on the bound. This means a Set<TypeName> collapses same-named type variables
+        // regardless of bound, which mirrors Dart's own rule that you can't declare the same
+        // type parameter name twice on one declaration.
+        val first = TypeVariableName("T", ClassName("Comparable"))
+        val second = TypeVariableName("T", ClassName("Object"))
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds `TypeVariableName` so that classes like `Box<T extends Comparable<T>>` and extensions like `extension<T extends Comparable<T>> on List<T>` can now be generated. Previously, only bare, unbounded type parameters were supported. Existing unbounded type parameter usage remains unaffected. This change is purely additive to `ClassBuilder` and `ExtensionBuilder`.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)