### PR TITLE
feat: add operator overloading support

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartModifier.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartModifier.kt
@@ -30,7 +30,8 @@ enum class DartModifier(
     CO_VARIANT("covariant", ModifierTarget.PARAMETER, ModifierTarget.PROPERTY),
     SEALED("sealed", ModifierTarget.CLASS),
     BASE("base", ModifierTarget.CLASS),
-    INTERFACE("interface", ModifierTarget.CLASS)
+    INTERFACE("interface", ModifierTarget.CLASS),
+    OPERATOR("operator", ModifierTarget.FUNCTION)
     ;
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -7,6 +7,7 @@ import net.theevilreaper.dartpoet.constructor.ConstructorBase
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.meta.SpecData
 import net.theevilreaper.dartpoet.meta.SpecMethods
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
 import net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefSpec
@@ -37,6 +38,7 @@ class ClassBuilder internal constructor(
     internal val propertyStack: MutableList<PropertySpec> = mutableListOf()
     internal val genericCasts: MutableList<TypeName> = mutableListOf()
     internal val functionStack: MutableList<FunctionSpec> = mutableListOf()
+    internal val operatorStack: MutableList<DartOperatorSpec> = mutableListOf()
     internal val enumPropertyStack: MutableList<EnumEntrySpec> = mutableListOf()
     internal val constantStack: MutableSet<ConstantPropertySpec> = mutableSetOf()
     internal val typedefs: MutableList<AbstractTypeDef<*>> = mutableListOf()
@@ -249,6 +251,33 @@ class ClassBuilder internal constructor(
      * @return the given instance of an [ClassBuilder]
      */
     fun function(function: () -> FunctionSpec) = this.function(function())
+
+    /**
+     * Add a [DartOperatorSpec] to the class builder.
+     * @param operator the operator to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun operator(operator: DartOperatorSpec) = apply {
+        checkNotLibrary(NO_MEMBERS_ON_LIBRARIES)
+        this.operatorStack += operator
+    }
+
+    /**
+     * Add a [DartOperatorSpec] to the class builder over a lambda reference.
+     * @param operator the operator to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun operator(operator: () -> DartOperatorSpec) = this.operator(operator())
+
+    /**
+     * Add an array of [DartOperatorSpec] to the class builder.
+     * @param operators the operators to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun operators(vararg operators: DartOperatorSpec) = apply {
+        checkNotLibrary(NO_MEMBERS_ON_LIBRARIES)
+        this.operatorStack += operators
+    }
 
     /**
      * Add a [ConstructorSpec] to the class builder.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -11,6 +11,7 @@ import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.constructor.ConstructorBase
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.util.toImmutableList
@@ -43,6 +44,7 @@ class ClassSpec internal constructor(
     internal val interfaces: List<TypeName> = builder.interfaces.toImmutableList()
     internal val typeDefs: List<AbstractTypeDef<*>> = builder.typedefs.toImmutableList()
     internal val functions: Set<FunctionSpec> = builder.functionStack.toImmutableSet()
+    internal val operators: Set<DartOperatorSpec> = builder.operatorStack.toImmutableSet()
     internal val properties: Set<PropertySpec> = builder.propertyStack.toImmutableSet()
     internal val constructors: Set<ConstructorBase> = builder.constructorStack.toImmutableSet()
     internal val enumPropertyStack: List<EnumEntrySpec> = builder.enumPropertyStack.toImmutableList()
@@ -52,7 +54,7 @@ class ClassSpec internal constructor(
      * Returns true when the class has no content to generate.
      */
     internal val hasNoContent: Boolean
-        get() = functions.isEmpty() && properties.isEmpty() && constructors.isEmpty() && constantStack.isEmpty() && enumPropertyStack.isEmpty()
+        get() = functions.isEmpty() && properties.isEmpty() && constructors.isEmpty() && constantStack.isEmpty() && enumPropertyStack.isEmpty() && operators.isEmpty()
 
     init {
         if (isLibrary) {
@@ -91,6 +93,14 @@ class ClassSpec internal constructor(
 
         check(interfaces.size == interfaces.distinct().size) {
             "Duplicate interface type(s) found: ${interfaces.groupingBy { it }.eachCount().filterValues { it > 1 }.keys}"
+        }
+
+        check(operators.size == operators.distinctBy { it.operator }.size) {
+            "Duplicate operator(s) found: ${operators.groupingBy { it.operator }.eachCount().filterValues { it > 1 }.map { it.key.symbol }}"
+        }
+
+        check(!isAnonymous || operators.isEmpty()) {
+            "An anonymous class can't declare operators"
         }
 
         if (classType == ClassType.CLASS || classType == ClassType.ABSTRACT) {
@@ -136,6 +146,7 @@ class ClassSpec internal constructor(
 
         classBuilder.propertyStack.addAll(properties)
         classBuilder.functionStack.addAll(functions)
+        classBuilder.operatorStack.addAll(operators)
         classBuilder.constructorStack.addAll(constructors)
         classBuilder.constantStack.addAll(constantStack)
         classBuilder.typedefs.addAll(typeDefs)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
@@ -8,6 +8,7 @@ import net.theevilreaper.dartpoet.directive.Directive
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
@@ -53,6 +54,20 @@ internal fun Set<FunctionSpec>.emitFunctions(
     forEachIndexed { index, functionSpec ->
         if (index > 0) emit(NEW_LINE)
         emitBlock(functionSpec)
+        if (emitNewLines && index < size - 1) emit(NEW_LINE)
+    }
+}
+
+internal fun Set<DartOperatorSpec>.emitOperators(
+    codeWriter: CodeWriter,
+    emitBlock: (DartOperatorSpec) -> Unit = { it.write(codeWriter) },
+) = with(codeWriter) {
+    if (isEmpty()) return@with
+    val emitNewLines = size > 1
+
+    forEachIndexed { index, operatorSpec ->
+        if (index > 0) emit(NEW_LINE)
+        emitBlock(operatorSpec)
         if (emitNewLines && index < size - 1) emit(NEW_LINE)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/WriterHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/WriterHelper.kt
@@ -1,6 +1,7 @@
 package net.theevilreaper.dartpoet.code
 
 import net.theevilreaper.dartpoet.code.writer.*
+import net.theevilreaper.dartpoet.code.writer.operator.OperatorWriter
 import net.theevilreaper.dartpoet.code.writer.typedef.TypeDefWriter
 import org.jetbrains.annotations.ApiStatus.Internal
 
@@ -31,4 +32,5 @@ internal object WriterHelper {
     internal val parameterWriter by lazy { ParameterWriter() }
     internal val propertyWriter by lazy { PropertyWriter() }
     internal val typeDefWriter by lazy { TypeDefWriter() }
+    internal val operatorWriter by lazy { OperatorWriter() }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -7,6 +7,7 @@ import net.theevilreaper.dartpoet.code.*
 import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.code.emitConstructors
 import net.theevilreaper.dartpoet.code.emitFunctions
+import net.theevilreaper.dartpoet.code.emitOperators
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.util.*
@@ -127,8 +128,14 @@ internal class ClassWriter : Writeable<ClassSpec> {
 
         spec.functions.emitFunctions(writer)
 
+        if (spec.functions.isNotEmpty() && spec.operators.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+            writer.emit(NEW_LINE)
+        }
+        spec.operators.emitOperators(writer)
+
         writer.unindent()
-        if (spec.functions.isNotEmpty()) {
+        if (spec.functions.isNotEmpty() || spec.operators.isNotEmpty()) {
             writer.emit(NEW_LINE)
         }
         writer.emit("}")

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriter.kt
@@ -1,0 +1,14 @@
+package net.theevilreaper.dartpoet.code.writer.operator
+
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.Writeable
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+
+class OperatorWriter : Writeable<DartOperatorSpec> {
+    override fun write(
+        spec: DartOperatorSpec,
+        writer: CodeWriter
+    ) {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriter.kt
@@ -1,14 +1,65 @@
 package net.theevilreaper.dartpoet.code.writer.operator
 
+import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.DocumentationAppender
 import net.theevilreaper.dartpoet.code.Writeable
+import net.theevilreaper.dartpoet.code.emitAnnotations
+import net.theevilreaper.dartpoet.function.FunctionType
 import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 
-class OperatorWriter : Writeable<DartOperatorSpec> {
+internal class OperatorWriter : Writeable<DartOperatorSpec>, DocumentationAppender {
+
     override fun write(
         spec: DartOperatorSpec,
         writer: CodeWriter
     ) {
-        TODO("Not yet implemented")
+        emitDocumentation(spec.docs, writer)
+        spec.annotations.emitAnnotations(codeWriter = writer)
+
+        writer.emitCode("%T", spec.returnType)
+        writer.emitSpace()
+        writer.emitCode("%L", DartModifier.OPERATOR.identifier)
+        writer.emitSpace()
+        writer.emitCode("%L", spec.operator.symbol)
+
+        writeParameters(spec, writer)
+        writeBody(spec, writer)
+    }
+
+    private fun writeParameters(spec: DartOperatorSpec, writer: CodeWriter) {
+        if (!spec.hasParameters) {
+            writer.emitEmptyRoundBrackets()
+            return
+        }
+
+        writer.emit("(")
+        spec.parameters.forEachIndexed { index, parameter ->
+            parameter.write(writer)
+            if (index < spec.parameters.size - 1) {
+                writer.emit(", ")
+            }
+        }
+        writer.emit(")")
+    }
+
+    private fun writeBody(spec: DartOperatorSpec, writer: CodeWriter) {
+        when (spec.type) {
+            FunctionType.STANDARD -> {
+                writer.emitSpace()
+                writer.emit("{\n")
+                writer.indent()
+                writer.emitCode(spec.body, ensureTrailingNewline = false)
+                writer.unindent()
+                writer.emit("\n}")
+            }
+
+            FunctionType.SHORTEN -> {
+                writer.emitSpace()
+                writer.emit(FunctionType.SHORTEN.identifier)
+                writer.emitSpace()
+                writer.emitCode(spec.body, ensureTrailingNewline = false)
+            }
+        }
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/BinaryOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/BinaryOperator.kt
@@ -1,5 +1,11 @@
 package net.theevilreaper.dartpoet.operator
 
+/**
+ * Enumerates Dart's overloadable binary operators. Each one takes exactly one parameter
+ * (the right-hand operand) when used in an `operator` declaration.
+ * @author theEvilReaper
+ * @since 2.1.0
+ */
 enum class BinaryOperator(
     override val symbol: String
 ) : DartOperator {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/BinaryOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/BinaryOperator.kt
@@ -1,0 +1,23 @@
+package net.theevilreaper.dartpoet.operator
+
+enum class BinaryOperator(
+    override val symbol: String
+) : DartOperator {
+    PLUS("+"),
+    MINUS("-"),
+    MULTIPLY("*"),
+    DIVIDE("/"),
+    INTEGER_DIVIDE("~/"),
+    MODULO("%"),
+    LESS_THAN("<"),
+    GREATER_THAN(">"),
+    LESS_THAN_OR_EQUAL("<="),
+    GREATER_THAN_OR_EQUAL(">="),
+    EQUAL("=="),
+    BITWISE_AND("&"),
+    BITWISE_OR("|"),
+    BITWISE_XOR("^"),
+    LEFT_SHIFT("<<"),
+    RIGHT_SHIFT(">>"),
+    UNSIGNED_RIGHT_SHIFT(">>>")
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperator.kt
@@ -1,6 +1,6 @@
 package net.theevilreaper.dartpoet.operator
 
-interface DartOperator {
+sealed interface DartOperator {
 
     val symbol: String
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperator.kt
@@ -1,0 +1,6 @@
+package net.theevilreaper.dartpoet.operator
+
+interface DartOperator {
+
+    val symbol: String
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperator.kt
@@ -1,6 +1,16 @@
 package net.theevilreaper.dartpoet.operator
 
+/**
+ * Marker interface for all Dart operators that can be overloaded via `operator` declarations.
+ * Implemented by [UnaryOperator], [BinaryOperator] and [IndexOperator], the only operator
+ * categories Dart itself allows to be overloaded.
+ * @author theEvilReaper
+ * @since 2.1.0
+ */
 sealed interface DartOperator {
 
+    /**
+     * The Dart symbol this operator is declared with, e.g. `+` or `[]=`.
+     */
     val symbol: String
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
@@ -1,0 +1,39 @@
+package net.theevilreaper.dartpoet.operator
+
+class DartOperatorBuilder {
+
+    var operator: DartOperator? = null
+    var parameters: List<String> = emptyList()
+    var returnType: String? = null
+
+    /**
+     * Sets the operator type.
+     *
+     * @param operator the operator type
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun operator(operator: DartOperator) = apply { this.operator = operator }
+
+    /**
+     * Sets the parameters for the operator.
+     *
+     * @param parameters the parameters for the operator
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun parameters(parameters: List<String>) = apply { this.parameters = parameters }
+
+    /**
+     * Sets the return type of the operator.
+     *
+     * @param returnType the return type of the operator
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun returnType(returnType: String) = apply { this.returnType = returnType }
+
+    /**
+     * Builds the [DartOperatorSpec] instance.
+     *
+     * @return the built [DartOperatorSpec] instance
+     */
+    fun build(): DartOperatorSpec = DartOperatorSpec(this)
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
@@ -9,6 +9,14 @@ import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.util.NO_PARAMETER_TYPE
 
+/**
+ * The builder class to describe an operator overload for a Dart class.
+ * Only supports the parameter shape Dart's `operator` grammar actually allows: a flat list
+ * of simple positional parameters, no named/optional/default parameters.
+ * @param operator the operator this builder describes
+ * @author theEvilReaper
+ * @since 2.1.0
+ */
 class DartOperatorBuilder internal constructor(
     val operator: DartOperator
 ) : AnnotationMethods<DartOperatorBuilder> {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
@@ -1,18 +1,22 @@
 package net.theevilreaper.dartpoet.operator
 
-class DartOperatorBuilder {
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.TypeName
 
-    var operator: DartOperator? = null
-    var parameters: List<String> = emptyList()
-    var returnType: String? = null
+class DartOperatorBuilder(
+    val operator: DartOperator
+) {
+
+    var parameters: MutableList<ParameterSpec> = mutableListOf()
+    var returnType: TypeName? = null
 
     /**
-     * Sets the operator type.
+     * Adds a parameter to the operator.
      *
-     * @param operator the operator type
+     * @param parameter the parameter to add
      * @return the given instance of a [DartOperatorBuilder]
      */
-    fun operator(operator: DartOperator) = apply { this.operator = operator }
+    fun parameter(parameter: ParameterSpec) = apply { this.parameters.add(parameter) }
 
     /**
      * Sets the parameters for the operator.
@@ -20,7 +24,7 @@ class DartOperatorBuilder {
      * @param parameters the parameters for the operator
      * @return the given instance of a [DartOperatorBuilder]
      */
-    fun parameters(parameters: List<String>) = apply { this.parameters = parameters }
+    fun parameters(parameters: List<ParameterSpec>) = apply { this.parameters.addAll(parameters) }
 
     /**
      * Sets the return type of the operator.
@@ -28,7 +32,7 @@ class DartOperatorBuilder {
      * @param returnType the return type of the operator
      * @return the given instance of a [DartOperatorBuilder]
      */
-    fun returnType(returnType: String) = apply { this.returnType = returnType }
+    fun returnType(returnType: TypeName) = apply { this.returnType = returnType }
 
     /**
      * Builds the [DartOperatorSpec] instance.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorBuilder.kt
@@ -1,14 +1,24 @@
 package net.theevilreaper.dartpoet.operator
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.code.CodeBlock
+import net.theevilreaper.dartpoet.function.FunctionType
+import net.theevilreaper.dartpoet.meta.AnnotationData
+import net.theevilreaper.dartpoet.meta.AnnotationMethods
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.util.NO_PARAMETER_TYPE
 
-class DartOperatorBuilder(
+class DartOperatorBuilder internal constructor(
     val operator: DartOperator
-) {
+) : AnnotationMethods<DartOperatorBuilder> {
 
-    var parameters: MutableList<ParameterSpec> = mutableListOf()
+    internal val parameters: MutableList<ParameterSpec> = mutableListOf()
     var returnType: TypeName? = null
+    internal val annotationData: AnnotationData = AnnotationData()
+    internal val body: CodeBlock.Builder = CodeBlock.builder()
+    internal val docs: MutableList<CodeBlock> = mutableListOf()
+    internal var type: FunctionType = FunctionType.STANDARD
 
     /**
      * Adds a parameter to the operator.
@@ -16,7 +26,10 @@ class DartOperatorBuilder(
      * @param parameter the parameter to add
      * @return the given instance of a [DartOperatorBuilder]
      */
-    fun parameter(parameter: ParameterSpec) = apply { this.parameters.add(parameter) }
+    fun parameter(parameter: ParameterSpec) = apply {
+        check(!parameter.hasNoTypeName) { NO_PARAMETER_TYPE }
+        this.parameters.add(parameter)
+    }
 
     /**
      * Sets the parameters for the operator.
@@ -24,7 +37,12 @@ class DartOperatorBuilder(
      * @param parameters the parameters for the operator
      * @return the given instance of a [DartOperatorBuilder]
      */
-    fun parameters(parameters: List<ParameterSpec>) = apply { this.parameters.addAll(parameters) }
+    fun parameters(parameters: List<ParameterSpec>) = apply {
+        parameters.forEach {
+            check(!it.hasNoTypeName) { NO_PARAMETER_TYPE }
+        }
+        this.parameters.addAll(parameters)
+    }
 
     /**
      * Sets the return type of the operator.
@@ -33,6 +51,52 @@ class DartOperatorBuilder(
      * @return the given instance of a [DartOperatorBuilder]
      */
     fun returnType(returnType: TypeName) = apply { this.returnType = returnType }
+
+    /**
+     * Adds a documentation comment line to the operator.
+     * @param format the string which contains the content and the format
+     * @param args the arguments for the format string
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun doc(format: String, vararg args: Any) = apply {
+        this.docs.add(CodeBlock.of(format.replace(' ', '·'), *args))
+    }
+
+    /**
+     * Sets whether the operator body is written as a block (`{ }`) or a shorthand (`=>`).
+     * @param type the [FunctionType] to use
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun type(type: FunctionType) = apply { this.type = type }
+
+    /**
+     * Adds formatted code to the operator body.
+     * @param format the string which contains the content and the format
+     * @param args the arguments for the format string
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun addCode(format: String, vararg args: Any?) = apply { this.body.add(format, *args) }
+
+    /**
+     * Adds a [CodeBlock] to the operator body.
+     * @param codeBlock the code block to add
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun addCode(codeBlock: CodeBlock) = apply { this.body.add(codeBlock) }
+
+    /**
+     * Adds named formatted code to the operator body.
+     * @param format the string which contains the content and the format
+     * @param args the named arguments for the format string
+     * @return the given instance of a [DartOperatorBuilder]
+     */
+    fun addNamedCode(format: String, args: Map<String, *>) = apply { this.body.addNamed(format, args) }
+
+    override fun annotation(annotation: () -> AnnotationSpec) = apply { this.annotationData.annotation(annotation) }
+
+    override fun annotation(annotation: AnnotationSpec) = apply { this.annotationData.annotation(annotation) }
+
+    override fun annotations(vararg annotations: AnnotationSpec) = apply { this.annotationData.annotations(*annotations) }
 
     /**
      * Builds the [DartOperatorSpec] instance.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
@@ -1,0 +1,19 @@
+package net.theevilreaper.dartpoet.operator
+
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.TypeName
+
+class DartOperatorSpec(
+    val builder: DartOperatorBuilder
+) {
+
+    val operator: DartOperator
+    val parameters: List<ParameterSpec>
+    val returnType: TypeName
+
+    companion object {
+
+        fun builder(): DartOperatorBuilder = DartOperatorBuilder()
+    }
+
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
@@ -2,18 +2,40 @@ package net.theevilreaper.dartpoet.operator
 
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.TypeName
+import org.jetbrains.annotations.Contract
 
 class DartOperatorSpec(
     val builder: DartOperatorBuilder
 ) {
+    val operator: DartOperator = builder.operator
+    val parameters: List<ParameterSpec> = builder.parameters
+    val returnType: TypeName? = builder.returnType
 
-    val operator: DartOperator
-    val parameters: List<ParameterSpec>
-    val returnType: TypeName
-
-    companion object {
-
-        fun builder(): DartOperatorBuilder = DartOperatorBuilder()
+    /**
+     * Creates a new instance of [DartOperatorBuilder] with the same properties as this instance.
+     * @return the created [DartOperatorBuilder] instance
+     */
+    @Contract(pure = true)
+    fun toBuilder(): DartOperatorBuilder {
+        val builder = DartOperatorBuilder(this.operator)
+        builder.parameters.addAll(this.parameters)
+        builder.returnType = this.returnType
+        return builder
     }
 
+    /**
+     * The companion object contains some helper methods to create a new instance of a [DartOperatorBuilder].
+     * @since 2.1.0
+     * @author theEvilReaper
+     */
+    companion object {
+
+        /**
+         * Creates a new instance of [DartOperatorBuilder] with the specified operator.
+         * @param operator the operator to build the builder for
+         * @return the created [DartOperatorBuilder] instance
+         */
+        @JvmStatic
+        fun builder(operator: DartOperator): DartOperatorBuilder = DartOperatorBuilder(operator)
+    }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
@@ -13,6 +13,14 @@ import net.theevilreaper.dartpoet.util.toImmutableList
 import net.theevilreaper.dartpoet.util.toImmutableSet
 import org.jetbrains.annotations.Contract
 
+/**
+ * The spec class contains all relevant information about an operator overload in dart.
+ * An [net.theevilreaper.dartpoet.code.writer.operator.OperatorWriter] instance reads the data
+ * from it to write the operator declaration into the class structure from dart.
+ * @param builder the builder instance to retrieve the data from
+ * @author theEvilReaper
+ * @since 2.1.0
+ */
 class DartOperatorSpec internal constructor(
     builder: DartOperatorBuilder
 ) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
@@ -1,15 +1,71 @@
 package net.theevilreaper.dartpoet.operator
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.code.CodeBlock
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.WriterHelper
+import net.theevilreaper.dartpoet.code.buildCodeString
+import net.theevilreaper.dartpoet.function.FunctionType
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterType
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.util.toImmutableList
+import net.theevilreaper.dartpoet.util.toImmutableSet
 import org.jetbrains.annotations.Contract
 
-class DartOperatorSpec(
-    val builder: DartOperatorBuilder
+class DartOperatorSpec internal constructor(
+    builder: DartOperatorBuilder
 ) {
-    val operator: DartOperator = builder.operator
-    val parameters: List<ParameterSpec> = builder.parameters
-    val returnType: TypeName? = builder.returnType
+    internal val operator: DartOperator = builder.operator
+    internal val parameters: List<ParameterSpec> = builder.parameters.toImmutableList()
+    internal val returnType: TypeName = checkNotNull(builder.returnType) { "The return type of an operator can't be null" }
+    internal val body: CodeBlock = builder.body.build()
+    internal val docs: List<CodeBlock> = builder.docs.toImmutableList()
+    internal val annotations: Set<AnnotationSpec> = builder.annotationData.annotations.toImmutableSet()
+    internal val type: FunctionType = builder.type
+
+    internal val hasParameters: Boolean = parameters.isNotEmpty()
+
+    init {
+        val requiredParameterCount = when (val op = operator) {
+            is UnaryOperator -> 0
+            is BinaryOperator -> 1
+            is IndexOperator -> when (op) {
+                IndexOperator.INDEX -> 1
+                IndexOperator.INDEX_ASSIGN -> 2
+            }
+        }
+
+        check(parameters.size == requiredParameterCount) {
+            "Operator '${operator.symbol}' requires exactly $requiredParameterCount parameter(s), but got ${parameters.size}"
+        }
+
+        parameters.forEach {
+            check(it.type == ParameterType.POSITIONAL) {
+                "Operator parameters must be simple positional parameters, but got ${it.type} for '${it.name}'"
+            }
+            check(!it.hasInitializer) {
+                "Operator parameters can't have a default value ('${it.name}')"
+            }
+        }
+
+        check(body.isNotEmpty()) { "An operator must have a body" }
+    }
+
+    /**
+     * Calls the [net.theevilreaper.dartpoet.code.writer.operator.OperatorWriter] to write the content
+     * from this spec into a [CodeWriter].
+     * @param codeWriter the writer instance
+     */
+    internal fun write(codeWriter: CodeWriter) {
+        WriterHelper.operatorWriter.write(this, codeWriter)
+    }
+
+    /**
+     * Returns a [String] representation from the operator spec.
+     * @return the generated representation as string
+     */
+    override fun toString() = buildCodeString { write(this) }
 
     /**
      * Creates a new instance of [DartOperatorBuilder] with the same properties as this instance.
@@ -20,6 +76,10 @@ class DartOperatorSpec(
         val builder = DartOperatorBuilder(this.operator)
         builder.parameters.addAll(this.parameters)
         builder.returnType = this.returnType
+        builder.body.add(this.body)
+        builder.docs.addAll(this.docs)
+        builder.annotations(*this.annotations.toTypedArray())
+        builder.type(this.type)
         return builder
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/IndexOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/IndexOperator.kt
@@ -1,0 +1,15 @@
+package net.theevilreaper.dartpoet.operator
+
+/**
+ * Represents Dart's index operators, `[]` and `[]=`.
+ * Unlike [BinaryOperator] and [UnaryOperator] these two have a fixed, non-symmetric
+ * arity: `[]` takes the index, `[]=` takes the index and the value being assigned.
+ * @author theEvilReaper
+ * @since 2.1.0
+ */
+enum class IndexOperator(
+    override val symbol: String
+) : DartOperator {
+    INDEX("[]"),
+    INDEX_ASSIGN("[]=");
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/UnaryOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/UnaryOperator.kt
@@ -4,6 +4,5 @@ enum class UnaryOperator(
     override val symbol: String
 ) : DartOperator {
     NEGATE("-"),
-    COMPLEMENT("~"),
-    NOT("!");
+    COMPLEMENT("~");
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/UnaryOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/UnaryOperator.kt
@@ -1,0 +1,9 @@
+package net.theevilreaper.dartpoet.operator
+
+enum class UnaryOperator(
+    override val symbol: String
+) : DartOperator {
+    NEGATE("-"),
+    COMPLEMENT("~"),
+    NOT("!");
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/UnaryOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/UnaryOperator.kt
@@ -1,5 +1,12 @@
 package net.theevilreaper.dartpoet.operator
 
+/**
+ * Enumerates Dart's overloadable unary operators. Each one takes no parameters when used
+ * in an `operator` declaration. Dart doesn't allow overloading `!` (boolean negation), so
+ * only `-` (unary minus) and `~` (bitwise complement) are represented here.
+ * @author theEvilReaper
+ * @since 2.1.0
+ */
 enum class UnaryOperator(
     override val symbol: String
 ) : DartOperator {

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterOperatorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterOperatorTest.kt
@@ -1,0 +1,197 @@
+package net.theevilreaper.dartpoet.code.writer
+
+import com.google.common.truth.Truth.assertThat
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.operator.BinaryOperator
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.operator.UnaryOperator
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.BOOLEAN
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.VOID
+import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@DisplayName("Test operator generation as part of a class")
+class ClassWriterOperatorTest {
+
+    private companion object {
+
+        @JvmStatic
+        private fun classesWithOperators() = Stream.of(
+            Arguments.of(
+                ClassSpec.builder("Vector")
+                    .property {
+                        PropertySpec.builder("x", INTEGER).build()
+                    }
+                    .property {
+                        PropertySpec.builder("y", INTEGER).build()
+                    }
+                    .constructor(
+                        ConstructorSpec.builder("Vector")
+                            .parameter(ParameterSpec.positional("x").build())
+                            .parameter(ParameterSpec.positional("y").build())
+                            .build()
+                    )
+                    .operator(
+                        DartOperatorSpec.builder(BinaryOperator.PLUS)
+                            .returnType(ClassName("Vector"))
+                            .parameter(ParameterSpec.positional("other", ClassName("Vector")).build())
+                            .addCode("return %L;", "Vector(x + other.x, y + other.y)")
+                            .build()
+                    )
+                    .build(),
+                """
+                |class Vector {
+                |
+                |  int x;
+                |  int y;
+                |
+                |  Vector(this.x, this.y);
+                |
+                |  Vector operator +(Vector other) {
+                |    return Vector(x + other.x, y + other.y);
+                |  }
+                |}
+                """.trimMargin()
+            ),
+            Arguments.of(
+                ClassSpec.builder("Box")
+                    .property {
+                        PropertySpec.builder("_open", BOOLEAN).initWith("false").build()
+                    }
+                    .function(
+                        FunctionSpec.builder("open")
+                            .returns(VOID)
+                            .addCode("_open = !_open;")
+                            .build()
+                    )
+                    .operator(
+                        DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                            .returnType(ClassName("Box"))
+                            .addCode("return %L;", "Box()")
+                            .build()
+                    )
+                    .build(),
+                """
+                |class Box {
+                |
+                |  bool _open = false;
+                |
+                |  void open() {
+                |    _open = !_open;
+                |  }
+                |
+                |  Box operator -() {
+                |    return Box();
+                |  }
+                |}
+                """.trimMargin()
+            ),
+            Arguments.of(
+                ClassSpec.builder("Money")
+                    .property {
+                        PropertySpec.builder("cents", INTEGER).build()
+                    }
+                    .constructor(
+                        ConstructorSpec.builder("Money")
+                            .parameter(ParameterSpec.positional("cents").build())
+                            .build()
+                    )
+                    .function(
+                        FunctionSpec.builder("isZero")
+                            .returns(BOOLEAN)
+                            .addCode("return cents == 0;")
+                            .build()
+                    )
+                    .operator(
+                        DartOperatorSpec.builder(BinaryOperator.MINUS)
+                            .returnType(ClassName("Money"))
+                            .parameter(ParameterSpec.positional("other", ClassName("Money")).build())
+                            .addCode("return %L;", "Money(cents - other.cents)")
+                            .build()
+                    )
+                    .operator(
+                        DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                            .returnType(ClassName("Money"))
+                            .addCode("return %L;", "Money(-cents)")
+                            .build()
+                    )
+                    .build(),
+                """
+                |class Money {
+                |
+                |  int cents;
+                |
+                |  Money(this.cents);
+                |
+                |  bool isZero() {
+                |    return cents == 0;
+                |  }
+                |
+                |  Money operator -(Money other) {
+                |    return Money(cents - other.cents);
+                |  }
+                |
+                |  Money operator -() {
+                |    return Money(-cents);
+                |  }
+                |}
+                """.trimMargin()
+            )
+        )
+    }
+
+    @DartAnalyzeCase
+    @ParameterizedTest
+    @MethodSource("classesWithOperators")
+    fun `test classes with operators`(classSpec: ClassSpec, expected: String) {
+        assertThat(classSpec.toString()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `test duplicate operator symbol throws`() {
+        assertThrows(IllegalStateException::class.java) {
+            ClassSpec.builder("Vector")
+                .operator(
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(ClassName("Vector"))
+                        .parameter(ParameterSpec.positional("other", ClassName("Vector")).build())
+                        .addCode("return %L;", "this")
+                        .build()
+                )
+                .operator(
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(ClassName("Vector"))
+                        .parameter(ParameterSpec.positional("other", ClassName("Vector")).build())
+                        .addCode("return %L;", "this")
+                        .build()
+                )
+                .build()
+        }
+    }
+
+    @Test
+    fun `test operator on anonymous class throws`() {
+        assertThrows(IllegalStateException::class.java) {
+            ClassSpec.anonymousClassBuilder()
+                .operator(
+                    DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                        .returnType(BOOLEAN)
+                        .addCode("return %L;", "true")
+                        .build()
+                )
+                .build()
+        }
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterOperatorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterOperatorTest.kt
@@ -6,12 +6,14 @@ import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.operator.BinaryOperator
 import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.operator.IndexOperator
 import net.theevilreaper.dartpoet.operator.UnaryOperator
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.type.BOOLEAN
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
 import net.theevilreaper.dartpoet.type.VOID
 import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -145,6 +147,49 @@ class ClassWriterOperatorTest {
                 |
                 |  Money operator -() {
                 |    return Money(-cents);
+                |  }
+                |}
+                """.trimMargin()
+            ),
+            Arguments.of(
+                ClassSpec.builder("IntList")
+                    .property {
+                        PropertySpec.builder("_values", List::class.parameterizedBy(INTEGER)).build()
+                    }
+                    .constructor(
+                        ConstructorSpec.builder("IntList")
+                            .parameter(ParameterSpec.positional("_values").build())
+                            .build()
+                    )
+                    .operator(
+                        DartOperatorSpec.builder(IndexOperator.INDEX)
+                            .returnType(INTEGER)
+                            .parameter(ParameterSpec.positional("index", INTEGER).build())
+                            .addCode("return %L;", "_values[index]")
+                            .build()
+                    )
+                    .operator(
+                        DartOperatorSpec.builder(IndexOperator.INDEX_ASSIGN)
+                            .returnType(VOID)
+                            .parameter(ParameterSpec.positional("index", INTEGER).build())
+                            .parameter(ParameterSpec.positional("value", INTEGER).build())
+                            .addCode("%L = %L;", "_values[index]", "value")
+                            .build()
+                    )
+                    .build(),
+                """
+                |class IntList {
+                |
+                |  List<int> _values;
+                |
+                |  IntList(this._values);
+                |
+                |  int operator [](int index) {
+                |    return _values[index];
+                |  }
+                |
+                |  void operator []=(int index, int value) {
+                |    _values[index] = value;
                 |  }
                 |}
                 """.trimMargin()

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriterTest.kt
@@ -1,0 +1,137 @@
+package net.theevilreaper.dartpoet.code.writer.operator
+
+import com.google.common.truth.Truth.assertThat
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.function.FunctionType
+import net.theevilreaper.dartpoet.operator.BinaryOperator
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.operator.IndexOperator
+import net.theevilreaper.dartpoet.operator.UnaryOperator
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.BOOLEAN
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.VOID
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Test operator writer")
+class OperatorWriterTest {
+
+    @Test
+    fun `write binary operator with block body`() {
+        val operator = DartOperatorSpec.builder(BinaryOperator.PLUS)
+            .returnType(ClassName("Vector"))
+            .parameter(ParameterSpec.positional("other", ClassName("Vector")).build())
+            .addCode("return %L;", "Vector(x + other.x, y + other.y)")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            """
+            |Vector operator +(Vector other) {
+            |  return Vector(x + other.x, y + other.y);
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `write binary equals operator with shorthand body and override annotation`() {
+        val operator = DartOperatorSpec.builder(BinaryOperator.EQUAL)
+            .returnType(BOOLEAN)
+            .parameter(ParameterSpec.positional("other", ClassName("Object")).build())
+            .type(FunctionType.SHORTEN)
+            .annotation(AnnotationSpec.builder("override").build())
+            .addCode("other is Vector && x == other.x && y == other.y;")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            "@override\nbool operator ==(Object other) => other is Vector && x == other.x && y == other.y;"
+        )
+    }
+
+    @Test
+    fun `write unary negate operator`() {
+        val operator = DartOperatorSpec.builder(UnaryOperator.NEGATE)
+            .returnType(ClassName("Vector"))
+            .addCode("return %L;", "Vector(-x, -y)")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            """
+            |Vector operator -() {
+            |  return Vector(-x, -y);
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `write unary complement operator`() {
+        val operator = DartOperatorSpec.builder(UnaryOperator.COMPLEMENT)
+            .returnType(INTEGER)
+            .addCode("return %L;", "~value")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            """
+            |int operator ~() {
+            |  return ~value;
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `write index operator`() {
+        val operator = DartOperatorSpec.builder(IndexOperator.INDEX)
+            .returnType(INTEGER)
+            .parameter(ParameterSpec.positional("index", INTEGER).build())
+            .addCode("return %L;", "_values[index]")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            """
+            |int operator [](int index) {
+            |  return _values[index];
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `write index assign operator`() {
+        val operator = DartOperatorSpec.builder(IndexOperator.INDEX_ASSIGN)
+            .returnType(VOID)
+            .parameter(ParameterSpec.positional("index", INTEGER).build())
+            .parameter(ParameterSpec.positional("value", INTEGER).build())
+            .addCode("%L = %L;", "_values[index]", "value")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            """
+            |void operator []=(int index, int value) {
+            |  _values[index] = value;
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `write operator with doc comment`() {
+        val operator = DartOperatorSpec.builder(UnaryOperator.NEGATE)
+            .returnType(ClassName("Vector"))
+            .doc("Returns the inverted vector.")
+            .addCode("return %L;", "Vector(-x, -y)")
+            .build()
+
+        assertThat(operator.toString()).isEqualTo(
+            """
+            |/// Returns the inverted vector.
+            |Vector operator -() {
+            |  return Vector(-x, -y);
+            |}
+            """.trimMargin()
+        )
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpecTest.kt
@@ -1,0 +1,194 @@
+package net.theevilreaper.dartpoet.operator
+
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.VOID
+import net.theevilreaper.dartpoet.util.NO_PARAMETER_TYPE
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@DisplayName("Test DartOperatorSpec creation")
+class DartOperatorSpecTest {
+
+    private companion object {
+
+        @JvmStatic
+        private fun invalidOperatorArity(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                        .returnType(INTEGER)
+                        .parameter(ParameterSpec.positional("other", INTEGER).build())
+                        .addCode("return %L;", "-value")
+                        .build()
+                },
+                "Operator '-' requires exactly 0 parameter(s), but got 1"
+            ),
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(INTEGER)
+                        .addCode("return %L;", "value")
+                        .build()
+                },
+                "Operator '+' requires exactly 1 parameter(s), but got 0"
+            ),
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(IndexOperator.INDEX)
+                        .returnType(INTEGER)
+                        .addCode("return %L;", "value")
+                        .build()
+                },
+                "Operator '[]' requires exactly 1 parameter(s), but got 0"
+            ),
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(IndexOperator.INDEX_ASSIGN)
+                        .returnType(VOID)
+                        .parameter(ParameterSpec.positional("index", INTEGER).build())
+                        .addCode("%L = %L;", "_values[index]", "value")
+                        .build()
+                },
+                "Operator '[]=' requires exactly 2 parameter(s), but got 1"
+            )
+        )
+
+        @JvmStatic
+        private fun invalidOperatorParameterKinds(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(INTEGER)
+                        .parameter(ParameterSpec.named("other", INTEGER).build())
+                        .addCode("return %L;", "value")
+                        .build()
+                },
+                "Operator parameters must be simple positional parameters, but got NAMED for 'other'"
+            ),
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(INTEGER)
+                        .parameter(ParameterSpec.optional("other", INTEGER).build())
+                        .addCode("return %L;", "value")
+                        .build()
+                },
+                "Operator parameters must be simple positional parameters, but got OPTIONAL for 'other'"
+            ),
+            Arguments.of(
+                {
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(INTEGER)
+                        .parameter(ParameterSpec.required("other", INTEGER).build())
+                        .addCode("return %L;", "value")
+                        .build()
+                },
+                "Operator parameters must be simple positional parameters, but got REQUIRED for 'other'"
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidOperatorArity")
+    fun `test invalid operator arity`(specBuilder: () -> DartOperatorSpec, message: String) {
+        val exception = assertThrows(IllegalStateException::class.java) { specBuilder() }
+        assertEquals(message, exception.message)
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidOperatorParameterKinds")
+    fun `test invalid operator parameter kinds`(specBuilder: () -> DartOperatorSpec, message: String) {
+        val exception = assertThrows(IllegalStateException::class.java) { specBuilder() }
+        assertEquals(message, exception.message)
+    }
+
+    @Test
+    fun `test operator parameter with default value throws`() {
+        val exception = assertThrows(IllegalStateException::class.java) {
+            DartOperatorSpec.builder(BinaryOperator.PLUS)
+                .returnType(INTEGER)
+                .parameter(ParameterSpec.positional("other", INTEGER).initializer("%L", "0").build())
+                .addCode("return %L;", "value")
+                .build()
+        }
+        assertEquals("Operator parameters can't have a default value ('other')", exception.message)
+    }
+
+    @Test
+    fun `test operator parameter without a type throws`() {
+        val exception = assertThrows(IllegalStateException::class.java) {
+            DartOperatorSpec.builder(BinaryOperator.PLUS)
+                .returnType(INTEGER)
+                .parameter(ParameterSpec.positional("other").build())
+                .addCode("return %L;", "value")
+                .build()
+        }
+        assertEquals(NO_PARAMETER_TYPE, exception.message)
+    }
+
+    @Test
+    fun `test operator parameters without a type throws`() {
+        val exception = assertThrows(IllegalStateException::class.java) {
+            DartOperatorSpec.builder(IndexOperator.INDEX_ASSIGN)
+                .returnType(VOID)
+                .parameters(
+                    listOf(
+                        ParameterSpec.positional("index", INTEGER).build(),
+                        ParameterSpec.positional("value").build()
+                    )
+                )
+                .addCode("%L = %L;", "_values[index]", "value")
+                .build()
+        }
+        assertEquals(NO_PARAMETER_TYPE, exception.message)
+    }
+
+    @Test
+    fun `test operator without a return type throws`() {
+        assertThrows(IllegalStateException::class.java) {
+            DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                .addCode("return %L;", "-value")
+                .build()
+        }
+    }
+
+    @Test
+    fun `test operator without a body throws`() {
+        val exception = assertThrows(IllegalStateException::class.java) {
+            DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                .returnType(INTEGER)
+                .build()
+        }
+        assertEquals("An operator must have a body", exception.message)
+    }
+
+    @Test
+    fun `test spec to builder conversion`() {
+        val operatorSpec = DartOperatorSpec.builder(BinaryOperator.PLUS)
+            .returnType(INTEGER)
+            .parameter(ParameterSpec.positional("other", INTEGER).build())
+            .doc("Adds two values.")
+            .annotation(AnnotationSpec.builder("override").build())
+            .addCode("return %L;", "value + other")
+            .build()
+
+        val specAsBuilder = operatorSpec.toBuilder()
+
+        assertEquals(operatorSpec.operator, specAsBuilder.operator)
+        assertEquals(operatorSpec.returnType, specAsBuilder.returnType)
+        assertEquals(operatorSpec.parameters, specAsBuilder.parameters)
+        assertEquals(operatorSpec.docs, specAsBuilder.docs)
+        assertEquals(operatorSpec.annotations, specAsBuilder.annotationData.annotations.toSet())
+        assertEquals(operatorSpec.type, specAsBuilder.type)
+        assertTrue { specAsBuilder.body.isNotEmpty() }
+    }
+}


### PR DESCRIPTION
## Proposed changes

This pull request adds support for generating overloaded operators in DartPoet. It allows operators such as `+`, `-`, `==`, and `[]` to be defined when generating Dart classes and extensions. Previously, DartPoet did not provide any functionality for generating overloaded operators.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)