### PR TITLE
chore(operator): enhance operator overload support

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriter.kt
@@ -5,6 +5,7 @@ import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.DocumentationAppender
 import net.theevilreaper.dartpoet.code.Writeable
 import net.theevilreaper.dartpoet.code.emitFunctions
+import net.theevilreaper.dartpoet.code.emitOperators
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.util.CURLY_CLOSE
 import net.theevilreaper.dartpoet.util.NEW_LINE
@@ -49,6 +50,12 @@ internal class ExtensionWriter : Writeable<ExtensionSpec>, DocumentationAppender
         writer.indent()
 
         spec.functions.emitFunctions(writer)
+
+        if (spec.functions.isNotEmpty() && spec.operators.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+            writer.emit(NEW_LINE)
+        }
+        spec.operators.emitOperators(writer)
 
         writer.emit(NEW_LINE)
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriter.kt
@@ -7,6 +7,7 @@ import net.theevilreaper.dartpoet.code.Writeable
 import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.function.FunctionType
 import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.util.SEMICOLON
 
 internal class OperatorWriter : Writeable<DartOperatorSpec>, DocumentationAppender {
 
@@ -44,6 +45,11 @@ internal class OperatorWriter : Writeable<DartOperatorSpec>, DocumentationAppend
     }
 
     private fun writeBody(spec: DartOperatorSpec, writer: CodeWriter) {
+        if (spec.body.isEmpty()) {
+            writer.emit(SEMICOLON)
+            return
+        }
+
         when (spec.type) {
             FunctionType.STANDARD -> {
                 writer.emitSpace()

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionBuilder.kt
@@ -2,6 +2,7 @@ package net.theevilreaper.dartpoet.extension
 
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.type.TypeVariableName
@@ -22,6 +23,7 @@ class ExtensionBuilder(
     internal var genericTypes: MutableList<TypeName> = mutableListOf()
     internal var endWithNewLine: Boolean = false
     internal val functionStack: MutableList<FunctionSpec> = mutableListOf()
+    internal val operatorStack: MutableList<DartOperatorSpec> = mutableListOf()
     internal val docs: MutableList<CodeBlock> = mutableListOf()
 
     /**
@@ -60,6 +62,33 @@ class ExtensionBuilder(
      */
     fun functions(vararg functions: FunctionSpec) = apply {
         this.functionStack += functions
+    }
+
+    /**
+     * Adds a new [DartOperatorSpec] to the extension.
+     * @param operator the operator to add
+     * @return the current builder instance
+     */
+    fun operator(operator: DartOperatorSpec) = apply {
+        this.operatorStack += operator
+    }
+
+    /**
+     * Adds a new [DartOperatorSpec] to the extension using a lambda expression.
+     * @param operator a lambda expression that creates the operator to add
+     * @return the current builder instance
+     */
+    fun operator(operator: () -> DartOperatorSpec) = apply {
+        this.operatorStack += operator()
+    }
+
+    /**
+     * Adds multiple [DartOperatorSpec] instances to the extension.
+     * @param operators the operators to add
+     * @return the current builder instance
+     */
+    fun operators(vararg operators: DartOperatorSpec) = apply {
+        this.operatorStack += operators
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
@@ -6,6 +6,7 @@ import net.theevilreaper.dartpoet.code.WriterHelper
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.code.writer.ExtensionWriter
 import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 import net.theevilreaper.dartpoet.parameter.ParameterBuilder
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
@@ -33,9 +34,10 @@ class ExtensionSpec internal constructor(
     internal val endWithNewLine: Boolean = builder.endWithNewLine
     internal val genericType: List<TypeName> = builder.genericTypes.toImmutableList()
     internal val functions: Set<FunctionSpec> = builder.functionStack.toImmutableSet()
+    internal val operators: Set<DartOperatorSpec> = builder.operatorStack.toImmutableSet()
     internal val docs: List<CodeBlock> = builder.docs.toImmutableList()
     internal val hasGenericCast: Boolean = builder.genericTypes.isNotEmpty()
-    internal val hasNoContent: Boolean = builder.functionStack.isEmpty()
+    internal val hasNoContent: Boolean = builder.functionStack.isEmpty() && builder.operatorStack.isEmpty()
 
     internal val joinedRawTypes by lazy {
         if (genericType.isEmpty()) return@lazy EMPTY_STRING
@@ -76,6 +78,10 @@ class ExtensionSpec internal constructor(
                 """.trimIndent()
             }
         }
+
+        check(operators.size == operators.distinctBy { it.operator }.size) {
+            "Duplicate operator(s) found: ${operators.groupingBy { it.operator }.eachCount().filterValues { it > 1 }.map { it.key.symbol }}"
+        }
     }
 
     /**
@@ -103,6 +109,7 @@ class ExtensionSpec internal constructor(
         builder.endWithNewLine = this.endWithNewLine
         builder.docs.addAll(this.docs)
         builder.functionStack.addAll(this.functions)
+        builder.operatorStack.addAll(this.operators)
         return builder
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/BinaryOperator.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/BinaryOperator.kt
@@ -19,6 +19,11 @@ enum class BinaryOperator(
     GREATER_THAN(">"),
     LESS_THAN_OR_EQUAL("<="),
     GREATER_THAN_OR_EQUAL(">="),
+    /**
+     * Overriding `==` without also overriding `hashCode` is flagged by Dart's analyzer/lints
+     * in most projects. When generating a class with this operator, consider also generating
+     * a matching `hashCode` getter/method (DartPoet doesn't enforce or generate this automatically).
+     */
     EQUAL("=="),
     BITWISE_AND("&"),
     BITWISE_OR("|"),

--- a/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpec.kt
@@ -57,7 +57,7 @@ class DartOperatorSpec internal constructor(
             }
         }
 
-        check(body.isNotEmpty()) { "An operator must have a body" }
+        check(!(type == FunctionType.SHORTEN && body.isEmpty())) { "Lambda can only be used with a body" }
     }
 
     /**

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterOperatorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterOperatorTest.kt
@@ -1,0 +1,49 @@
+package net.theevilreaper.dartpoet.code.writer
+
+import com.google.common.truth.Truth.assertThat
+import net.theevilreaper.dartpoet.extension.ExtensionSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.operator.UnaryOperator
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Test operator generation as part of an extension")
+class ExtensionWriterOperatorTest {
+
+    @DartAnalyzeCase
+    @Test
+    fun `test extension with function and operator`() {
+        val extension = ExtensionSpec.builder("ListExt", List::class.parameterizedBy(INTEGER))
+            .function(
+                FunctionSpec.builder("sum")
+                    .returns(INTEGER)
+                    .addCode("return fold(0, (a, b) => a + b);")
+                    .build()
+            )
+            .operator(
+                DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                    .returnType(List::class.parameterizedBy(INTEGER))
+                    .addCode("return %L;", "reversed.toList()")
+                    .build()
+            )
+            .build()
+
+        assertThat(extension.toString()).isEqualTo(
+            """
+            |extension ListExt on List<int> {
+            |  int sum() {
+            |    return fold(0, (a, b) => a + b);
+            |  }
+            |
+            |  List<int> operator -() {
+            |    return reversed.toList();
+            |  }
+            |}
+            """.trimMargin()
+        )
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/operator/OperatorWriterTest.kt
@@ -118,6 +118,16 @@ class OperatorWriterTest {
     }
 
     @Test
+    fun `write operator without a body`() {
+        val operator = DartOperatorSpec.builder(BinaryOperator.PLUS)
+            .returnType(INTEGER)
+            .parameter(ParameterSpec.positional("other", INTEGER).build())
+            .build()
+
+        assertThat(operator.toString()).isEqualTo("int operator +(int other);")
+    }
+
+    @Test
     fun `write operator with doc comment`() {
         val operator = DartOperatorSpec.builder(UnaryOperator.NEGATE)
             .returnType(ClassName("Vector"))

--- a/src/test/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpecTest.kt
@@ -1,6 +1,11 @@
 package net.theevilreaper.dartpoet.extension
 
+import net.theevilreaper.dartpoet.operator.BinaryOperator
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.operator.UnaryOperator
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.INTEGER
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import org.junit.jupiter.api.Assertions.*
@@ -67,11 +72,60 @@ class ExtensionSpecTest {
         val extensionSpec = ExtensionSpec.builder("isEmpty", "String")
             .endsWithNewLine(true)
             .doc("%C", "This is a test line")
+            .operator(
+                DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                    .returnType(net.theevilreaper.dartpoet.type.BOOLEAN)
+                    .addCode("return %L;", "true")
+                    .build()
+            )
             .build()
         val specAsBuilder = extensionSpec.toBuilder()
         assertEquals(extensionSpec.name, specAsBuilder.name)
         assertEquals(extensionSpec.extClass, specAsBuilder.extClass)
         assertTrue { specAsBuilder.docs.isNotEmpty() }
         assertEquals(extensionSpec.endWithNewLine, specAsBuilder.endWithNewLine)
+        assertEquals(extensionSpec.operators.toList(), specAsBuilder.operatorStack)
+    }
+
+    @Test
+    fun `test duplicate operator symbol throws`() {
+        assertThrows(IllegalStateException::class.java) {
+            ExtensionSpec.builder("NumExt", Int::class)
+                .operator(
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(INTEGER)
+                        .parameter(ParameterSpec.positional("other", INTEGER).build())
+                        .addCode("return %L;", "this + other")
+                        .build()
+                )
+                .operator(
+                    DartOperatorSpec.builder(BinaryOperator.PLUS)
+                        .returnType(INTEGER)
+                        .parameter(ParameterSpec.positional("other", INTEGER).build())
+                        .addCode("return %L;", "this + other")
+                        .build()
+                )
+                .build()
+        }
+    }
+
+    @Test
+    fun `test binary and unary operator sharing a symbol does not throw`() {
+        val extension = ExtensionSpec.builder("VectorExt", ClassName("Vector"))
+            .operator(
+                DartOperatorSpec.builder(BinaryOperator.MINUS)
+                    .returnType(ClassName("Vector"))
+                    .parameter(ParameterSpec.positional("other", ClassName("Vector")).build())
+                    .addCode("return %L;", "this")
+                    .build()
+            )
+            .operator(
+                DartOperatorSpec.builder(UnaryOperator.NEGATE)
+                    .returnType(ClassName("Vector"))
+                    .addCode("return %L;", "this")
+                    .build()
+            )
+            .build()
+        assertTrue { extension.toString().isNotEmpty() }
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/operator/DartOperatorSpecTest.kt
@@ -1,6 +1,7 @@
 package net.theevilreaper.dartpoet.operator
 
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.function.FunctionType
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.INTEGER
 import net.theevilreaper.dartpoet.type.VOID
@@ -162,13 +163,23 @@ class DartOperatorSpecTest {
     }
 
     @Test
-    fun `test operator without a body throws`() {
+    fun `test operator with empty body and standard type builds successfully`() {
+        val operator = DartOperatorSpec.builder(UnaryOperator.NEGATE)
+            .returnType(INTEGER)
+            .build()
+        assertTrue { operator.body.isEmpty() }
+        assertEquals(FunctionType.STANDARD, operator.type)
+    }
+
+    @Test
+    fun `test operator with empty body and shorten type throws`() {
         val exception = assertThrows(IllegalStateException::class.java) {
             DartOperatorSpec.builder(UnaryOperator.NEGATE)
                 .returnType(INTEGER)
+                .type(FunctionType.SHORTEN)
                 .build()
         }
-        assertEquals("An operator must have a body", exception.message)
+        assertEquals("Lambda can only be used with a body", exception.message)
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Adds operator-overload support for Dart extension declarations (ExtensionBuilder/ExtensionSpec/ExtensionWriter), in addition to the existing support for classes. Also allows abstract, body-less operator  declarations (operator +(Foo other);), mirroring the existing behavior for regular functions. Adds a documentation note on the ==/hashCode convention to BinaryOperator.EQUAL.                               
  
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)