### PR TITLE
 fix: correct typedef and parameter-checker validation bugs

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
@@ -6,7 +6,7 @@ import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.directive.Directive
-import net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefSpec
+import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.util.DEFAULT_INDENT
@@ -21,7 +21,7 @@ class DartFileBuilder(
     internal val annotations: MutableList<AnnotationSpec> = mutableListOf()
     internal val extensionStack: MutableList<ExtensionSpec> = mutableListOf()
     internal val constants: MutableSet<ConstantPropertySpec> = mutableSetOf()
-    internal val typeDefs: MutableList<AliasTypeDefSpec> = mutableListOf()
+    internal val typeDefs: MutableList<AbstractTypeDef<*>> = mutableListOf()
     internal var indent = DEFAULT_INDENT
 
     /**
@@ -78,7 +78,7 @@ class DartFileBuilder(
      * @param typeDef the type definition to add
      * @return the current instance of [DartFileBuilder]
      */
-    fun typeDef(typeDef: AliasTypeDefSpec) = apply {
+    fun typeDef(typeDef: AbstractTypeDef<*>) = apply {
         this.typeDefs += typeDef
     }
 
@@ -87,7 +87,7 @@ class DartFileBuilder(
      * @param typeDef the type definitions to add
      * @return the current instance of [DartFileBuilder]
      */
-    fun typeDef(vararg typeDef: AliasTypeDefSpec) = apply {
+    fun typeDef(vararg typeDef: AbstractTypeDef<*>) = apply {
         this.typeDefs += typeDef
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -78,6 +78,7 @@ class ClassBuilder internal constructor(
      * @param typeDefSpec the typedef to add
      */
     fun typedef(typeDefSpec: AbstractTypeDef<*>) = apply {
+        checkNotLibrary(NO_MEMBERS_ON_LIBRARIES)
         this.typedefs += typeDefSpec
     }
 
@@ -86,6 +87,7 @@ class ClassBuilder internal constructor(
      * @param typeDefSpec the typedefs to add
      */
     fun typedef(vararg typeDefSpec: AbstractTypeDef<*>) = apply {
+        checkNotLibrary(NO_MEMBERS_ON_LIBRARIES)
         this.typedefs += typeDefSpec
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -54,7 +54,7 @@ class ClassSpec internal constructor(
      * Returns true when the class has no content to generate.
      */
     internal val hasNoContent: Boolean
-        get() = functions.isEmpty() && properties.isEmpty() && constructors.isEmpty() && constantStack.isEmpty() && enumPropertyStack.isEmpty() && operators.isEmpty()
+        get() = functions.isEmpty() && properties.isEmpty() && constructors.isEmpty() && constantStack.isEmpty() && enumPropertyStack.isEmpty() && operators.isEmpty() && typeDefs.isEmpty()
 
     init {
         if (isLibrary) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -114,6 +114,12 @@ internal class ClassWriter : Writeable<ClassSpec> {
             writer.emit(NEW_LINE)
         }
 
+        spec.typeDefs.emitTypeDefs(writer)
+
+        if (spec.typeDefs.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+        }
+
         spec.properties.emitProperties(writer)
 
         if (spec.properties.isNotEmpty()) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpec.kt
@@ -28,18 +28,14 @@ class FunctionTypeDefSpec(
         writer.emitCode("%T", Function::class.asTypeName())
         val parameterData: ParameterData<ParameterSpec> = ParameterData.of(this)
 
-        if (parameterData.hasParameters) {
-            // A Dart function type can't declare default parameter values, those only belong on
-            // the function/constructor that actually implements the signature.
-            ParameterHelper.writeParameters(
-                parameterData,
-                writer,
-                indent = parameterData.requiredParameters.size > 1,
-                writeInitializers = false,
-            )
-        } else {
-            writer.emitEmptyRoundBrackets()
-        }
+        // A Dart function type can't declare default parameter values, those only belong on
+        // the function/constructor that actually implements the signature.
+        ParameterHelper.writeParameters(
+            parameterData,
+            writer,
+            indent = parameterData.requiredParameters.size > 1,
+            writeInitializers = false,
+        )
         writer.emitCode(SEMICOLON)
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterChecker.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/parameter/ParameterChecker.kt
@@ -18,7 +18,7 @@ internal object ParameterChecker {
     fun checkRequiredPositional(parameters: List<ParameterSpec>) {
         if (parameters.isEmpty()) return
         parameters.forEach {
-            require(it.hasInitializer) {
+            require(!it.hasInitializer) {
                 "Required parameters must not have an initializer"
             }
         }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileBuilderTypeDefTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileBuilderTypeDefTest.kt
@@ -1,0 +1,29 @@
+package net.theevilreaper.dartpoet
+
+import com.google.common.truth.Truth.assertThat
+import net.theevilreaper.dartpoet.function.typedef.function.FunctionTypeDefSpec
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * [DartFileBuilder.typeDef] is currently typed to accept only [net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefSpec].
+ * A [FunctionTypeDefSpec] built via `TypeDef.function(...).build()` is typed as `AbstractTypeDef<*>` and can't be
+ * passed to [DartFileBuilder.typeDef] at all - it doesn't compile, since [FunctionTypeDefSpec] isn't a subtype of
+ * `AliasTypeDefSpec`. Since that failure can't be expressed as a runtime assertion, this test instead checks
+ * reflectively whether a [FunctionTypeDefSpec] could be assigned to the declared parameter type of the
+ * `typeDef(...)` overload, so it fails today and starts passing once the parameter type is widened to
+ * `AbstractTypeDef<*>` (or another common supertype of both typedef kinds).
+ */
+@DisplayName("Test that DartFileBuilder.typeDef accepts any AbstractTypeDef")
+class DartFileBuilderTypeDefTest {
+
+    @Test
+    fun `test typeDef overload accepts a FunctionTypeDefSpec instead of only AliasTypeDefSpec`() {
+        val singleArgOverload = DartFileBuilder::class.java.methods
+            .filter { it.name == "typeDef" && !it.isVarArgs }
+            .single { it.parameterCount == 1 }
+
+        assertThat(FunctionTypeDefSpec::class.java)
+            .isAssignableTo(singleArgOverload.parameterTypes[0])
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/LibraryClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/LibraryClassTest.kt
@@ -5,6 +5,7 @@ import net.theevilreaper.dartpoet.clazz.ClassBuilder
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.function.typedef.TypeDef
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.type.ClassName
@@ -83,6 +84,14 @@ class LibraryClassTest {
     fun `test library class can't declare constants`() {
         val exception = assertThrows<IllegalStateException> {
             builder.constant(ConstantPropertySpec.classConst("id", Int::class).initWith("%L", 1).build())
+        }
+        assertThat(exception.message).isEqualTo("A library class can't declare functions, properties, constructors or constants")
+    }
+
+    @Test
+    fun `test library class can't declare typedefs`() {
+        val exception = assertThrows<IllegalStateException> {
+            builder.typedef(TypeDef.alias("JsonMap").returns(ClassName("Map")).build())
         }
         assertThat(exception.message).isEqualTo("A library class can't declare functions, properties, constructors or constants")
     }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriterTest.kt
@@ -2,7 +2,9 @@ package net.theevilreaper.dartpoet.code.writer
 
 import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.function.typedef.TypeDef
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
+import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
 import org.junit.jupiter.api.DisplayName
@@ -71,6 +73,26 @@ class ClassWriterTest {
             |
             |  static const String test = 'Test';
             |  static const int maxId = 100;
+            |
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test class writing with a typedef emits the typedef in its body`() {
+        val clazz = ClassSpec.builder("TestClass")
+            .typedef(
+                TypeDef.alias("JsonMap")
+                    .returns(ClassName("Map"))
+                    .build()
+            )
+            .build()
+        assertThat(clazz.toString()).isEqualTo(
+            """
+            |class TestClass {
+            |
+            |  typedef JsonMap = Map;
             |
             |}
             """.trimMargin()

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
@@ -224,4 +224,21 @@ class TypeDefWriterTest {
         }
         Truth.assertThat(exception.message).isEqualTo("Optional parameters must be nullable or have an initializer")
     }
+
+    @Test
+    fun `test typedef with non-nullable optional parameter renders without its initializer`() {
+        // A function typedef never renders parameter initializers (Dart forbids default values on a bare
+        // function type), but a non-nullable optional parameter without a rendered default is still valid
+        // Dart for a function type - unlike for a concrete function/method declaration, there's no
+        // implementation that would need the default to actually fall back to. Confirmed with `dart analyze`.
+        val typeDef = TypeDef.function("ValueUpdate", genericClassName)
+            .returns(genericClassName)
+            .parameter(
+                ParameterSpec.optional("data", Int::class)
+                    .initializer("%L", "0")
+                    .build()
+            )
+            .build()
+        typeDef.verifyDartOutput("typedef ValueUpdate<E> = E Function([int data]);")
+    }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpecTest.kt
@@ -1,0 +1,16 @@
+package net.theevilreaper.dartpoet.function.typedef.function
+
+import net.theevilreaper.dartpoet.function.typedef.TypeDef
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Test FunctionTypeDefSpec edge cases")
+class FunctionTypeDefSpecTest {
+
+    @Test
+    fun `test function typedef without parameters emits empty round brackets`() {
+        val function = TypeDef.function("VoidCallback").returns(Void::class).build()
+        function.verifyDartOutput("typedef VoidCallback = void Function();")
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterCheckerTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/parameter/ParameterCheckerTest.kt
@@ -1,0 +1,27 @@
+package net.theevilreaper.dartpoet.parameter
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("Test ParameterChecker validation rules")
+class ParameterCheckerTest {
+
+    @Test
+    fun `test checkRequiredPositional accepts a parameter without an initializer`() {
+        val parameter = ParameterSpec.positional("id", Int::class).build()
+        ParameterChecker.checkRequiredPositional(listOf(parameter))
+    }
+
+    @Test
+    fun `test checkRequiredPositional rejects a parameter with an initializer`() {
+        val parameter = ParameterSpec.positional("id", Int::class)
+            .initializer("%L", "0")
+            .build()
+        val exception = assertThrows<IllegalArgumentException> {
+            ParameterChecker.checkRequiredPositional(listOf(parameter))
+        }
+        assertThat(exception.message).isEqualTo("Required parameters must not have an initializer")
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fixes an inverted required-parameter check, widens DartFile typedefs to accept function typedefs, and stops class typedefs from being silently dropped on library/named classes. Also guards typedef() against library classes and simplifies the zero-parameter typedef branch. Covered by new/updated unit tests; full suite and dartAnalyzeCorpus pass.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)