### PR TITLE
feat(typedef): add support for documentation comments and annotations

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/typedef/TypeDefWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/typedef/TypeDefWriter.kt
@@ -2,7 +2,9 @@ package net.theevilreaper.dartpoet.code.writer.typedef
 
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.DocumentationAppender
 import net.theevilreaper.dartpoet.code.Writeable
+import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
 import net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefSpec
 
@@ -13,7 +15,7 @@ import net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefSpec
  * @version 1.0.0
  * @author theEvilReaper
  */
-class TypeDefWriter : Writeable<AbstractTypeDef<*>> {
+class TypeDefWriter : Writeable<AbstractTypeDef<*>>, DocumentationAppender {
 
     /**
      * Appends the [AliasTypeDefSpec] to the given [CodeWriter].
@@ -21,6 +23,8 @@ class TypeDefWriter : Writeable<AbstractTypeDef<*>> {
      * @param writer the writer to append the data
      */
     override fun write(spec: AbstractTypeDef<*>, writer: CodeWriter) {
+        emitDocumentation(spec.docs, writer)
+        spec.annotations.emitAnnotations(writer, inLineAnnotations = false)
         writer.emit(DartModifier.TYPEDEF.identifier)
         writer.emitSpace()
         writer.emitCode("%T", spec.type)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/AbstractTypeDef.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/AbstractTypeDef.kt
@@ -1,9 +1,13 @@
 package net.theevilreaper.dartpoet.function.typedef
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.WriterHelper
 import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.util.toImmutableList
+import net.theevilreaper.dartpoet.util.toImmutableSet
 
 /**
  * Abstract base class for all typedef specifications.
@@ -18,11 +22,20 @@ import net.theevilreaper.dartpoet.type.TypeName
  *
  * @param T the concrete builder type used to recreate or modify this typedef
  * @property type the type of the typedef
+ * @property docs the list of documentation blocks
+ * @property annotations the set of annotations applied to the typedef
  *
  * @author theEvilReaper
  * @since 1.0.0
  */
-abstract class AbstractTypeDef<T> internal constructor(val type: TypeName) {
+abstract class AbstractTypeDef<T> internal constructor(
+    val type: TypeName,
+    docs: List<CodeBlock> = emptyList(),
+    annotations: Set<AnnotationSpec> = emptySet(),
+) {
+    val docs: List<CodeBlock> = docs.toImmutableList()
+    val annotations: Set<AnnotationSpec> = annotations.toImmutableSet()
+
 
     /**
      * Trigger the writing process from the [TypeDefWriter] to write the spec into dart code.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/alias/AliasTypeDefBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/alias/AliasTypeDefBuilder.kt
@@ -1,6 +1,10 @@
 package net.theevilreaper.dartpoet.function.typedef.alias
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.meta.AnnotationData
+import net.theevilreaper.dartpoet.meta.AnnotationMethods
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
 import net.theevilreaper.dartpoet.type.asTypeName
@@ -12,12 +16,63 @@ import kotlin.reflect.KClass
  *
  * @param name the name of the type definition.
  */
-class AliasTypeDefBuilder internal constructor(val name: TypeName) {
+class AliasTypeDefBuilder internal constructor(val name: TypeName) : AnnotationMethods<AliasTypeDefBuilder> {
+
+    internal val annotationData: AnnotationData = AnnotationData()
+    internal val docs: MutableList<CodeBlock> = mutableListOf()
 
     /**
      * The return type of the type definition.
      */
     var returnType: TypeName? = null
+
+    /**
+     * Add a comment for the typedef.
+     * Note this comment will be generated over the typedef.
+     * @param format the string which contains the content and the format
+     * @param args the arguments for the format string
+     * @return the current [AliasTypeDefBuilder] instance
+     */
+    fun doc(format: String, vararg args: Any) = apply {
+        this.docs.add(CodeBlock.of(format.replace(' ', '·'), *args))
+    }
+
+    /**
+     * Add a [CodeBlock] as comment for the typedef.
+     * @param codeBlock the [CodeBlock] to add
+     * @return the current [AliasTypeDefBuilder] instance
+     */
+    fun doc(codeBlock: CodeBlock) = apply {
+        this.docs.add(codeBlock)
+    }
+
+    /**
+     * Add a single [AnnotationSpec] via lambda reference.
+     * @param annotation the lambda reference to the annotation
+     * @return the current [AliasTypeDefBuilder] instance
+     */
+    override fun annotation(annotation: () -> AnnotationSpec) = apply {
+        this.annotationData.annotation(annotation)
+    }
+
+    /**
+     * Add a single [AnnotationSpec].
+     * @param annotation the annotation to add
+     * @return the current [AliasTypeDefBuilder] instance
+     */
+    override fun annotation(annotation: AnnotationSpec) = apply {
+        this.annotationData.annotation(annotation)
+    }
+
+    /**
+     * Add an array of [AnnotationSpec].
+     * @param annotations the annotations to add
+     * @return the current [AliasTypeDefBuilder] instance
+     */
+    override fun annotations(vararg annotations: AnnotationSpec) = apply {
+        this.annotationData.annotations(*annotations)
+    }
+
 
     /**
      * Sets the return type of the type definition.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/alias/AliasTypeDefSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/alias/AliasTypeDefSpec.kt
@@ -14,6 +14,8 @@ class AliasTypeDefSpec internal constructor(
     val builder: AliasTypeDefBuilder
 ): AbstractTypeDef<AliasTypeDefBuilder>(
     builder.name,
+    builder.docs,
+    builder.annotationData.annotations.toSet(),
 ) {
     internal val returnType = builder.returnType
 
@@ -34,6 +36,8 @@ class AliasTypeDefSpec internal constructor(
     override fun toBuilder(): AliasTypeDefBuilder {
         val newBuilder = AliasTypeDefBuilder(this.type)
         newBuilder.returnType = this.returnType
+        newBuilder.docs.addAll(this.docs)
+        newBuilder.annotations(*this.annotations.toTypedArray())
         return newBuilder
     }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefBuilder.kt
@@ -1,7 +1,10 @@
 package net.theevilreaper.dartpoet.function.typedef.function
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
-import net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefBuilder
+import net.theevilreaper.dartpoet.meta.AnnotationData
+import net.theevilreaper.dartpoet.meta.AnnotationMethods
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
@@ -10,7 +13,10 @@ import kotlin.reflect.KClass
 
 class FunctionTypeDefBuilder(
     val type: TypeName,
-) {
+) : AnnotationMethods<FunctionTypeDefBuilder> {
+
+    internal val annotationData: AnnotationData = AnnotationData()
+    internal val docs: MutableList<CodeBlock> = mutableListOf()
 
     /**
      * List of parameters associated with the type definition.
@@ -21,6 +27,54 @@ class FunctionTypeDefBuilder(
      * The return type of the type definition.
      */
     var returnType: TypeName = Void::class.asTypeName()
+
+    /**
+     * Add a comment for the function typedef.
+     * Note this comment will be generated over the typedef.
+     * @param format the string which contains the content and the format
+     * @param args the arguments for the format string
+     * @return the current [FunctionTypeDefBuilder] instance
+     */
+    fun doc(format: String, vararg args: Any) = apply {
+        this.docs.add(CodeBlock.of(format.replace(' ', '·'), *args))
+    }
+
+    /**
+     * Add a [CodeBlock] as comment for the function typedef.
+     * @param codeBlock the [CodeBlock] to add
+     * @return the current [FunctionTypeDefBuilder] instance
+     */
+    fun doc(codeBlock: CodeBlock) = apply {
+        this.docs.add(codeBlock)
+    }
+
+    /**
+     * Add a single [AnnotationSpec] via lambda reference.
+     * @param annotation the lambda reference to the annotation
+     * @return the current [FunctionTypeDefBuilder] instance
+     */
+    override fun annotation(annotation: () -> AnnotationSpec) = apply {
+        this.annotationData.annotation(annotation)
+    }
+
+    /**
+     * Add a single [AnnotationSpec].
+     * @param annotation the annotation to add
+     * @return the current [FunctionTypeDefBuilder] instance
+     */
+    override fun annotation(annotation: AnnotationSpec) = apply {
+        this.annotationData.annotation(annotation)
+    }
+
+    /**
+     * Add an array of [AnnotationSpec].
+     * @param annotations the annotations to add
+     * @return the current [FunctionTypeDefBuilder] instance
+     */
+    override fun annotations(vararg annotations: AnnotationSpec) = apply {
+        this.annotationData.annotations(*annotations)
+    }
+
 
     /**
      * Sets the return type of the type definition.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpec.kt
@@ -14,7 +14,9 @@ import net.theevilreaper.dartpoet.parameter.ParameterContext
 class FunctionTypeDefSpec(
     builder: FunctionTypeDefBuilder
 ) : AbstractTypeDef<FunctionTypeDefBuilder>(
-    builder.type
+    builder.type,
+    builder.docs,
+    builder.annotationData.annotations.toSet(),
 ), ParameterContext<ParameterSpec> by ParameterContext(builder.parameters) {
     internal val returnType: TypeName = builder.returnType
 
@@ -48,6 +50,8 @@ class FunctionTypeDefSpec(
         val newBuilder = FunctionTypeDefBuilder(this.type)
         newBuilder.returnType = this.returnType
         newBuilder.parameters.addAll(this.parameters)
+        newBuilder.docs.addAll(this.docs)
+        newBuilder.annotations(*this.annotations.toTypedArray())
         return newBuilder
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/TypeDefWriterTest.kt
@@ -2,6 +2,7 @@ package net.theevilreaper.dartpoet.code.writer
 
 import com.google.common.truth.Truth
 import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
@@ -240,5 +241,42 @@ class TypeDefWriterTest {
             )
             .build()
         typeDef.verifyDartOutput("typedef ValueUpdate<E> = E Function([int data]);")
+    }
+
+    @DartAnalyzeCase
+    @Test
+    fun `test alias typedef with docs and annotations renders properly`() {
+        val typeDef = TypeDef.alias("StringMap")
+            .doc("A map of strings.")
+            .annotation(AnnotationSpec.builder("deprecated").build())
+            .returns(Map::class.parameterizedBy(String::class.asTypeName(), String::class.asTypeName()))
+            .build()
+
+        typeDef.verifyDartOutput(
+            """
+            |/// A map of strings.
+            |@deprecated
+            |typedef StringMap = Map<String, String>;
+            """.trimMargin()
+        )
+    }
+
+    @DartAnalyzeCase
+    @Test
+    fun `test function typedef with docs and annotations renders properly`() {
+        val typeDef = TypeDef.function("EventHandler")
+            .doc("Handles an event.")
+            .annotation(AnnotationSpec.builder("deprecated").build())
+            .returns(Void::class)
+            .parameter(ParameterSpec.positional("event", String::class).build())
+            .build()
+
+        typeDef.verifyDartOutput(
+            """
+            |/// Handles an event.
+            |@deprecated
+            |typedef EventHandler = void Function(String event);
+            """.trimMargin()
+        )
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/typedef/AliasTypeDefSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/typedef/AliasTypeDefSpecTest.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.dartpoet.function.typedef
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.function.typedef.alias.AliasTypeDefSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
@@ -26,6 +27,25 @@ class AliasTypeDefSpecTest {
 
         assertInstanceOf<ClassName>(typeName)
         assertEquals("JsonAlias", typeName.getRawData(), "The raw data must be \"JsonAlias\"")
+    }
+
+    @Test
+    fun `test alias typedef with docs and annotations`() {
+        val annotation = AnnotationSpec.builder("deprecated").build()
+        val typeDef = TypeDef.alias("JsonMap")
+            .doc("A mapping of string keys to values.")
+            .annotation(annotation)
+            .returns(Map::class.parameterizedBy(String::class.asTypeName(), ClassName("dynamic")))
+            .build() as AliasTypeDefSpec
+
+        assertEquals(1, typeDef.docs.size)
+        assertEquals(1, typeDef.annotations.size)
+        assertEquals(setOf(annotation), typeDef.annotations)
+
+        val rebuilt = typeDef.toBuilder().build() as AliasTypeDefSpec
+        assertEquals(typeDef.docs.size, rebuilt.docs.size)
+        assertEquals(typeDef.annotations, rebuilt.annotations)
+        assertEquals(typeDef.returnType, rebuilt.returnType)
     }
 }
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/typedef/function/FunctionTypeDefSpecTest.kt
@@ -1,9 +1,12 @@
 package net.theevilreaper.dartpoet.function.typedef.function
 
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.function.typedef.TypeDef
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 @DisplayName("Test FunctionTypeDefSpec edge cases")
 class FunctionTypeDefSpecTest {
@@ -12,5 +15,26 @@ class FunctionTypeDefSpecTest {
     fun `test function typedef without parameters emits empty round brackets`() {
         val function = TypeDef.function("VoidCallback").returns(Void::class).build()
         function.verifyDartOutput("typedef VoidCallback = void Function();")
+    }
+
+    @Test
+    fun `test function typedef with docs and annotations`() {
+        val annotation = AnnotationSpec.builder("deprecated").build()
+        val typeDef = TypeDef.function("CustomHandler")
+            .doc("Handles a custom event.")
+            .annotation(annotation)
+            .returns(Void::class)
+            .parameter(ParameterSpec.positional("event", String::class).build())
+            .build() as FunctionTypeDefSpec
+
+        assertEquals(1, typeDef.docs.size)
+        assertEquals(1, typeDef.annotations.size)
+        assertEquals(setOf(annotation), typeDef.annotations)
+
+        val rebuilt = typeDef.toBuilder().build() as FunctionTypeDefSpec
+        assertEquals(typeDef.docs.size, rebuilt.docs.size)
+        assertEquals(typeDef.annotations, rebuilt.annotations)
+        assertEquals(typeDef.returnType, rebuilt.returnType)
+        assertEquals(typeDef.parameters.size, rebuilt.parameters.size)
     }
 }


### PR DESCRIPTION
## Proposed changes

Adds support for documentation comments (docs) and annotations to AbstractTypeDef and its corresponding builders (AliasTypeDefBuilder, FunctionTypeDefBuilder). The TypeDefWriter now properly emits documentation and annotations before the typedef keyword in generated Dart code. This enables type aliases and function typedefs to be fully documented and annotated (e.g., with deprecated).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)