### PR TITLE
chore(function): improve generic support

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriter.kt
@@ -51,8 +51,8 @@ internal class FunctionWriter : Writeable<FunctionSpec>, DocumentationAppender {
         writer.emitSpace()
         writer.emit(StringHelper.ensureVariableNameWithPrivateModifier(spec.name, spec.isPrivate))
 
-        if (spec.typeCast != null) {
-            writer.emitGenericBlock("%T", spec.typeCast)
+        if (spec.genericCasts.isNotEmpty()) {
+            writer.emitGenericBlock("%L", spec.genericDeclaration)
         }
 
         val parameterData = ParameterData.of(spec)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/extension/ExtensionSpec.kt
@@ -56,10 +56,7 @@ class ExtensionSpec internal constructor(
      * [joinedRawTypes] (bare names only, used by the validation in the `init` block below), this
      * must never be used for anything that compares against [extClass]'s raw data.
      */
-    internal val genericDeclaration by lazy {
-        if (genericType.isEmpty()) return@lazy EMPTY_STRING
-        genericType.joinToString(COMMA_SEPARATOR) { TypeVariableName.renderDeclaration(it) }
-    }
+    internal val genericDeclaration by lazy { TypeVariableName.renderDeclarationList(genericType) }
 
     /**
      * Performs checks on variables to avoid unwanted or incorrect data.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -8,6 +8,7 @@ import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.type.VOID
 import net.theevilreaper.dartpoet.type.asClassName
 import net.theevilreaper.dartpoet.type.asTypeName
@@ -29,7 +30,7 @@ class FunctionBuilder internal constructor(
     internal val parameters: MutableList<ParameterSpec> = mutableListOf()
     internal var async: Boolean = false
     internal val body: CodeBlock.Builder = CodeBlock.builder()
-    internal var typeCast: TypeName? = null
+    internal val genericCasts: MutableList<TypeName> = mutableListOf()
     internal var lambda: Boolean = false
     internal val docs: MutableList<CodeBlock> = mutableListOf()
     internal var type: FunctionType = FunctionType.STANDARD
@@ -62,31 +63,57 @@ class FunctionBuilder internal constructor(
     }
 
     /**
-     * This method allows to specify a type cast using a [TypeName] object.
-     * It sets the type cast for the current instance and returns the modified instance.
-     *
-     * @param cast the [TypeName] representing the type to cast to
-     * @return the involved builder instance
+     * Add a generic type to the function builder.
+     * @param type the [ClassName] to add
+     * @return the given instance of an [FunctionBuilder]
      */
-    fun typeCast(cast: TypeName) = apply { this.typeCast = cast }
+    fun generic(type: ClassName) = apply {
+        this.genericCasts += type
+    }
 
     /**
-     * This method allows to specify a type cast using a [ClassName] object.
-     * It sets the type cast for the current instance and returns the modified instance.
-     *
-     * @param cast the [ClassName] representing the type to cast to
-     * @return the involved builder instance
+     * Add a generic type to the function builder.
+     * @param type the [Type] to add
+     * @return the given instance of an [FunctionBuilder]
      */
-    fun typeCast(cast: ClassName) = apply { this.typeCast = cast }
+    fun generic(type: Type) = apply {
+        generic(TypeName.get(type) as ClassName)
+    }
 
     /**
-     * This method allows to specify a type cast using a [KClass] object.
-     * It sets the type cast for the current instance and returns the modified instance.
-     *
-     * @param cast the [KClass] representing the type to cast to
-     * @return the involved builder instance
+     * Add a generic type to the function builder.
+     * @param type the [KClass] to add
+     * @return the given instance of an [FunctionBuilder]
      */
-    fun typeCast(cast: KClass<*>) = apply { this.typeCast = cast.asTypeName() }
+    fun generic(type: KClass<*>) = apply {
+        generic(type.asClassName())
+    }
+
+    /**
+     * Add a bounded generic type parameter to the function builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [TypeName]
+     * @return the given instance of an [FunctionBuilder]
+     */
+    fun generic(name: String, bound: TypeName) = apply {
+        this.genericCasts += TypeVariableName(name, bound)
+    }
+
+    /**
+     * Add a bounded generic type parameter to the function builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [ClassName]
+     * @return the given instance of an [FunctionBuilder]
+     */
+    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
+
+    /**
+     * Add a bounded generic type parameter to the function builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a [KClass]
+     * @return the given instance of an [FunctionBuilder]
+     */
+    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
 
     fun addCode(format: String, vararg args: Any?) = apply {
         body.add(format, *args)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionSpec.kt
@@ -10,9 +10,11 @@ import net.theevilreaper.dartpoet.code.buildCodeString
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.type.asTypeName
 import net.theevilreaper.dartpoet.util.*
 import net.theevilreaper.dartpoet.parameter.ParameterContext
+import net.theevilreaper.dartpoet.util.toImmutableList
 import net.theevilreaper.dartpoet.util.toImmutableSet
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
@@ -40,7 +42,8 @@ class FunctionSpec internal constructor(
     }.filter { it != DartModifier.PRIVATE && it != DartModifier.PUBLIC }.toImmutableSet()
 
     internal val isPrivate = builder.specData.modifiers.remove(DartModifier.PRIVATE)
-    internal val typeCast = builder.typeCast
+    internal val genericCasts: List<TypeName> = builder.genericCasts.toImmutableList()
+    internal val genericDeclaration by lazy { TypeVariableName.renderDeclarationList(genericCasts) }
     internal val docs = builder.docs
 
     internal val hasMethodAccessorType = methodAccessorType != null
@@ -82,7 +85,7 @@ class FunctionSpec internal constructor(
         builder.modifiers(*this.modifiers.toTypedArray())
         builder.parameters.addAll(this.parameters)
         builder.async = this.isAsync
-        builder.typeCast = this.typeCast
+        builder.genericCasts.addAll(this.genericCasts)
         builder.methodAccessorType = this.methodAccessorType
         builder.body.formatParts.addAll(this.body.formatParts)
         builder.body.args.add(this.body.args)

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/TypeVariableName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/TypeVariableName.kt
@@ -2,6 +2,8 @@ package net.theevilreaper.dartpoet.type
 
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.buildCodeString
+import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
+import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import net.theevilreaper.dartpoet.util.NULLABLE_CHAR
 
 /**
@@ -64,6 +66,18 @@ class TypeVariableName internal constructor(
             val name = buildCodeString { typeName.emit(this) }
             val bound = (typeName as? TypeVariableName)?.bound ?: return name
             return "$name extends ${buildCodeString { bound.emit(this) }}"
+        }
+
+        /**
+         * Renders [typeNames] as a comma-separated generic-declaration list via [renderDeclaration],
+         * e.g. `T, E extends Comparable`. Returns an empty string for an empty list.
+         *
+         * Shared by every writer that emits a `<...>` type-parameter list at a declaration site
+         * (class, extension, function), so the join logic exists exactly once.
+         */
+        internal fun renderDeclarationList(typeNames: List<TypeName>): String {
+            if (typeNames.isEmpty()) return EMPTY_STRING
+            return typeNames.joinToString(COMMA_SEPARATOR) { renderDeclaration(it) }
         }
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/ExtensionWriterTest.kt
@@ -80,12 +80,6 @@ class ExtensionWriterTest {
                 "extension ListExt<T extends Comparable> on List<T> {}"
             ),
             Arguments.of(
-                ExtensionSpec.builder("ListExt", List::class.parameterizedBy(ClassName("T")))
-                    .genericTypes("T", String::class)
-                    .build(),
-                "extension ListExt<T extends String> on List<T> {}"
-            ),
-            Arguments.of(
                 ExtensionSpec.builder("MapExt", Map::class.parameterizedBy(ClassName("T"), ClassName("E")))
                     .genericTypes("T", ClassName("Comparable"))
                     .genericTypes(ClassName("E"))

--- a/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/code/writer/FunctionWriterTest.kt
@@ -13,15 +13,16 @@ import net.theevilreaper.dartpoet.type.FunctionTypeName
 import net.theevilreaper.dartpoet.type.INTEGER
 import net.theevilreaper.dartpoet.type.STRING
 import net.theevilreaper.dartpoet.type.ClassName
-import net.theevilreaper.dartpoet.type.DYNAMIC
 import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
 import net.theevilreaper.dartpoet.type.asClassName
+import net.theevilreaper.dartpoet.verify.DartAnalyzeCase
 import net.theevilreaper.dartpoet.verify.verifyDartOutput
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.lang.reflect.Type
 import java.util.stream.Stream
 
 @DisplayName("Test function writer")
@@ -30,18 +31,41 @@ class FunctionWriterTest {
     private companion object {
 
         @JvmStatic
-        private fun castFunctionWrite() = Stream.of(
-            Arguments.of(
-                FunctionSpec.builder("getId").returns(Int::class).typeCast(Int::class).build(),
-                "int getId<int>();"
-            ),
-            Arguments.of(
-                FunctionSpec.builder("getModels").returns(List::class.parameterizedBy(ClassName("Model")))
-                    .typeCast(List::class.parameterizedBy(DYNAMIC))
-                    .build(),
-                "List<Model> getModels<List<dynamic>>();",
+        private fun genericOverloadCases(): Stream<Arguments> {
+            val reflectType: Type = String::class.java
+            return Stream.of(
+                Arguments.of(
+                    FunctionSpec.builder("identity")
+                        .modifiers(DartModifier.EXTERNAL)
+                        .generic(String::class)
+                        .returns(ClassName("String"))
+                        .parameter(ParameterSpec.positional("value", ClassName("String")).build())
+                        .build(),
+                    "external String identity<String>(String value);"
+                ),
+                Arguments.of(
+                    FunctionSpec.builder("identity")
+                        .modifiers(DartModifier.EXTERNAL)
+                        .generic(reflectType)
+                        .returns(ClassName("String"))
+                        .parameter(ParameterSpec.positional("value", ClassName("String")).build())
+                        .build(),
+                    "external String identity<String>(String value);"
+                ),
+                Arguments.of(
+                    FunctionSpec.builder("max")
+                        .modifiers(DartModifier.EXTERNAL)
+                        .generic("T", Comparable::class)
+                        .returns(ClassName("T"))
+                        .parameters(
+                            ParameterSpec.positional("a", ClassName("T")).build(),
+                            ParameterSpec.positional("b", ClassName("T")).build()
+                        )
+                        .build(),
+                    "external T max<T extends Comparable>(T a, T b);"
+                ),
             )
-        )
+        }
 
         @JvmStatic
         private fun basicFunctionWrites(): Stream<Arguments> = Stream.of(
@@ -74,10 +98,23 @@ class FunctionWriterTest {
         )
     }
 
+    @DartAnalyzeCase
     @ParameterizedTest
-    @MethodSource("castFunctionWrite")
-    fun `test function write with cast typeNames`(functionSpec: FunctionSpec, expected: String) {
+    @MethodSource("genericOverloadCases")
+    fun `test generic function overloads produce equivalent output`(functionSpec: FunctionSpec, expected: String) {
         assertThat(functionSpec.toString()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `test generic function write with multiple type parameters`() {
+        val functionSpec = FunctionSpec.builder("map")
+            .modifiers(DartModifier.EXTERNAL)
+            .generic(ClassName("T"))
+            .generic(ClassName("R"))
+            .returns(ClassName("R"))
+            .parameter(ParameterSpec.positional("value", ClassName("T")).build())
+            .build()
+        functionSpec.verifyDartOutput("external R map<T, R>(T value);")
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -2,6 +2,7 @@ package net.theevilreaper.dartpoet.function
 
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.asTypeName
 import net.theevilreaper.dartpoet.util.NO_PARAMETER_TYPE
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -163,6 +164,7 @@ class FunctionSpecTest {
         val functionSpec = FunctionSpec.builder("getAmount")
             .returns(Int::class.asTypeName().copy(nullable = true))
             .async(false)
+            .generic("T", ClassName("Comparable"))
             .addCode("return %L", "10")
             .build()
         val specAsBuilder = functionSpec.toBuilder()
@@ -170,5 +172,6 @@ class FunctionSpecTest {
         assertEquals(functionSpec.returnType, specAsBuilder.returnType)
         assertFalse { specAsBuilder.async }
         assertTrue { specAsBuilder.body.isNotEmpty() }
+        assertEquals(functionSpec.genericCasts, specAsBuilder.genericCasts)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/type/FunctionTypeNameTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/type/FunctionTypeNameTest.kt
@@ -53,6 +53,20 @@ class FunctionTypeNameTest {
                     .parameter(ParameterSpec.positional("value", ClassName("T")).build())
                     .build()
             ),
+            Arguments.of(
+                "T Function(T value)",
+                FunctionTypeName.builder()
+                    .returns(TypeVariableName("T"))
+                    .parameter(ParameterSpec.positional("value", TypeVariableName("T")).build())
+                    .build()
+            ),
+            Arguments.of(
+                "T Function(T value)",
+                FunctionTypeName.builder()
+                    .returns(TypeVariableName("T", ClassName("Comparable")))
+                    .parameter(ParameterSpec.positional("value", TypeVariableName("T", ClassName("Comparable"))).build())
+                    .build()
+            ),
         )
     }
 


### PR DESCRIPTION
## Proposed changes

This replaces the legacy, never fully working typeCast mechanism on FunctionBuilder with proper `generic(...)` support, letting DartPoet generate generic function and method declarations consistent with the existing ClassBuilder and ExtensionBuilder API. It's a breaking change since `typeCast(...)` is removed entirely, and the type parameter rendering logic is now shared through one helper instead of being duplicated across writers. Test coverage was tightened as well, trimming redundant overload cases and verifying the new generic function tests against a real Dart analyzer run.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)