### PR TITLE
 feat(class): add support for the mixin 'on' clause

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,12 +10,15 @@ analyzer:
     # (e.g. a generated private class with nothing else in the file to reference it)
     # rather than a signal about DartPoet's output.
     unused_element: ignore
-    # Combined-inheritance corpus cases (extends/with/implements) reference illustrative
-    # superclass/mixin/interface names (e.g. `Bar`, `M1`, `I1`) that are never defined
-    # elsewhere in the isolated corpus file. That's expected here - these checks verify
-    # DartPoet emits valid extends/with/implements *syntax*, not that the referenced
-    # placeholder type names resolve to real declarations.
+    # Combined-inheritance corpus cases (extends/with/implements/on) reference illustrative
+    # superclass/mixin/interface/constraint names (e.g. `Bar`, `M1`, `I1`, `Base`) that are
+    # never defined elsewhere in the isolated corpus file. That's expected here - these checks
+    # verify DartPoet emits valid extends/with/implements/on *syntax*, not that the referenced
+    # placeholder type names resolve to real declarations. Dart reports an unresolved `on`
+    # constraint as both a specific and a generic diagnostic, so both are ignored here.
     extends_non_class: ignore
     mixin_of_non_class: ignore
     implements_non_class: ignore
     mixin_with_non_class_superclass: ignore
+    mixin_super_class_constraint_non_interface: ignore
+    undefined_class: ignore

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -43,6 +43,7 @@ class ClassBuilder internal constructor(
     internal var superClass: TypeName? = null
     internal val mixins: MutableList<TypeName> = mutableListOf()
     internal val interfaces: MutableList<TypeName> = mutableListOf()
+    internal val onTypes: MutableList<TypeName> = mutableListOf()
     internal var endWithNewLine = false
 
     /**
@@ -186,6 +187,36 @@ class ClassBuilder internal constructor(
     @JvmName("implementsTypes")
     fun implements(vararg interfaces: KClass<*>) = apply {
         this.interfaces += interfaces.map { it.asTypeName() }
+    }
+
+    /**
+     * Add one or more superclass constraints to a mixin via Dart's `on` clause.
+     * Only valid for a mixin declaration.
+     * @param onTypes the constraint types to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun on(vararg onTypes: TypeName) = apply {
+        this.onTypes += onTypes
+    }
+
+    /**
+     * Add one or more superclass constraints to a mixin via Dart's `on` clause.
+     * Only valid for a mixin declaration.
+     * @param onTypes the constraint types to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun on(vararg onTypes: Type) = apply {
+        this.onTypes += onTypes.map { it.asTypeName() }
+    }
+
+    /**
+     * Add one or more superclass constraints to a mixin via Dart's `on` clause.
+     * Only valid for a mixin declaration.
+     * @param onTypes the constraint types to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    fun on(vararg onTypes: KClass<*>) = apply {
+        this.onTypes += onTypes.map { it.asTypeName() }
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -41,6 +41,7 @@ class ClassSpec internal constructor(
     internal val superClass: TypeName? = builder.superClass
     internal val mixins: List<TypeName> = builder.mixins.toImmutableList()
     internal val interfaces: List<TypeName> = builder.interfaces.toImmutableList()
+    internal val onTypes: List<TypeName> = builder.onTypes.toImmutableList()
     internal val typeDefs: List<AbstractTypeDef<*>> = builder.typedefs.toImmutableList()
     internal val functions: Set<FunctionSpec> = builder.functionStack.toImmutableSet()
     internal val operators: Set<DartOperatorSpec> = builder.operatorStack.toImmutableSet()
@@ -79,8 +80,16 @@ class ClassSpec internal constructor(
             }
         }
 
+        check(isMixin || onTypes.isEmpty()) {
+            "Dart's 'on' clause is only allowed on a mixin declaration"
+        }
+
         check(mixins.size == mixins.distinct().size) {
             "Duplicate mixin type(s) found: ${mixins.groupingBy { it }.eachCount().filterValues { it > 1 }.keys}"
+        }
+
+        check(onTypes.size == onTypes.distinct().size) {
+            "Duplicate 'on' type(s) found: ${onTypes.groupingBy { it }.eachCount().filterValues { it > 1 }.keys}"
         }
 
         check(interfaces.size == interfaces.distinct().size) {
@@ -145,6 +154,7 @@ class ClassSpec internal constructor(
         classBuilder.superClass = superClass
         classBuilder.mixins.addAll(mixins)
         classBuilder.interfaces.addAll(interfaces)
+        classBuilder.onTypes.addAll(onTypes)
         classBuilder.genericCasts.addAll(genericCasts)
         return classBuilder
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -213,6 +213,14 @@ internal class ClassWriter : Writeable<ClassSpec> {
             writer.emitSpace()
         }
 
+        if (spec.onTypes.isNotEmpty()) {
+            writer.emitCode("%L", "on")
+            writer.emitSpace()
+            val joinedOnTypes = StringHelper.concatData(spec.onTypes, separator = COMMA_SEPARATOR) { it.toString() }
+            writer.emitCode("%L", joinedOnTypes)
+            writer.emitSpace()
+        }
+
         if (spec.interfaces.isNotEmpty()) {
             writer.emitCode("%L", "implements")
             writer.emitSpace()

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassInheritanceTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassInheritanceTest.kt
@@ -65,6 +65,17 @@ class ClassInheritanceTest {
             Arguments.of(
                 ClassSpec.mixinClass("Handler").implements(ClassName("I1")).build(),
                 "mixin Handler implements I1 {}"
+            ),
+            Arguments.of(
+                ClassSpec.mixinClass("Handler").on(ClassName("Base")).build(),
+                "mixin Handler on Base {}"
+            ),
+            Arguments.of(
+                ClassSpec.mixinClass("Handler")
+                    .on(ClassName("Base"), ClassName("Other"))
+                    .implements(ClassName("I1"))
+                    .build(),
+                "mixin Handler on Base, Other implements I1 {}"
             )
         )
 
@@ -110,6 +121,22 @@ class ClassInheritanceTest {
                         .build()
                 },
                 "Duplicate interface type(s) found: [I1]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Foo")
+                        .on(ClassName("Base"))
+                        .build()
+                },
+                "Dart's 'on' clause is only allowed on a mixin declaration"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.mixinClass("Handler")
+                        .on(ClassName("Base"), ClassName("Base"))
+                        .build()
+                },
+                "Duplicate 'on' type(s) found: [Base]"
             )
         )
     }


### PR DESCRIPTION
## Proposed changes

This adds an `on(...)` API to ClassBuilder, mirroring the existing `implements(...)` overloads, so DartPoet can now generate a mixin's superclass constraint clause such as `mixin Handler on Base implements  {}`. The new clause is validated the same way as the existing with and implements clauses, meaning it is rejected on non mixin declarations and checked for duplicate entries. Test coverage was added in `ClassInheritanceTest` for both valid and invalid combinations, verified against a real Dart analyzer run.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)