### PR TITLE
feat(type): add support for record types

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/ParameterizedTypeName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/ParameterizedTypeName.kt
@@ -6,6 +6,7 @@ import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import net.theevilreaper.dartpoet.util.GREATER_THAN_SIGN
 import net.theevilreaper.dartpoet.util.LESS_THAN_SIGN
+import net.theevilreaper.dartpoet.util.NULLABLE_CHAR
 import net.theevilreaper.dartpoet.util.StringHelper
 import org.jetbrains.annotations.ApiStatus
 import java.lang.reflect.Type
@@ -78,10 +79,6 @@ class ParameterizedTypeName internal constructor(
         }
 
         if (typeArguments.isNotEmpty()) {
-            // Dispatch each argument through emit() (like %T does), not toString(): TypeName.toString()
-            // goes through cachedString, which appends a nullable "?" on top of whatever emit() already
-            // wrote, doubling it for any TypeName whose own emit() self-appends "?" (e.g. ClassName,
-            // FunctionTypeName).
             val joinedArguments = StringHelper.concatData(
                 typeArguments,
                 prefix = LESS_THAN_SIGN,
@@ -89,6 +86,9 @@ class ParameterizedTypeName internal constructor(
                 postfix = GREATER_THAN_SIGN
             ) { buildCodeString { it.emit(this) } }
             out.emit(joinedArguments)
+        }
+        if (isNullable) {
+            out.emit(NULLABLE_CHAR)
         }
         return out
     }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/TypeName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/TypeName.kt
@@ -31,7 +31,6 @@ sealed class TypeName(val isNullable: Boolean) {
     private val cachedString: String by lazy {
         buildCodeString {
             emit(this)
-            if (isNullable) emit(NULLABLE_CHAR)
         }
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/record/RecordEntry.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/record/RecordEntry.kt
@@ -1,0 +1,42 @@
+package net.theevilreaper.dartpoet.type.record
+
+import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.asTypeName
+import kotlin.reflect.KClass
+
+/**
+ * Represents a single field entry in a Dart 3 record type.
+ *
+ * For positional fields, [name] is optional (purely descriptive in Dart type annotations).
+ * For named fields, [name] is required.
+ *
+ * @param typeName the [TypeName] of the record field
+ * @param name optional name or label of the record field
+ * @since 2.3.0
+ * @author theEvilReaper
+ */
+data class RecordEntry(
+    val typeName: TypeName,
+    val name: String? = null,
+) {
+    companion object {
+
+        /**
+         * Creates a [RecordEntry] with the given [typeName] and optional [name].
+         * @param typeName the type of the field
+         * @param name the optional name of the field
+         * @return the created [RecordEntry]
+         */
+        @JvmStatic
+        fun of(typeName: TypeName, name: String? = null) = RecordEntry(typeName, name)
+
+        /**
+         * Creates a [RecordEntry] with the given [type] converted to [TypeName] and optional [name].
+         * @param type the Kotlin class representing the type
+         * @param name the optional name of the field
+         * @return the created [RecordEntry]
+         */
+        @JvmStatic
+        fun of(type: KClass<*>, name: String? = null) = RecordEntry(type.asTypeName(), name)
+    }
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/record/RecordTypeBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/record/RecordTypeBuilder.kt
@@ -1,0 +1,137 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.type.record.RecordEntry
+import net.theevilreaper.dartpoet.util.toImmutableList
+import kotlin.reflect.KClass
+
+/**
+ * Builder for [RecordTypeName]. Entered via [RecordTypeName.builder].
+ *
+ * @since 2.3.0
+ * @author theEvilReaper
+ */
+class RecordTypeBuilder internal constructor() {
+
+    internal val positionalFields: MutableList<RecordEntry> = mutableListOf()
+    internal val namedFields: MutableList<RecordEntry> = mutableListOf()
+    internal var isNullable: Boolean = false
+
+    /**
+     * Adds a positional [RecordEntry] to the record type.
+     * @param recordEntry the entry to add
+     * @return the current builder instance
+     */
+    fun positional(recordEntry: RecordEntry) = apply {
+        positionalFields += recordEntry
+    }
+
+    /**
+     * Adds multiple positional [RecordEntry] instances to the record type.
+     * @param recordEntries the entries to add
+     * @return the current builder instance
+     */
+    fun positional(vararg recordEntries: RecordEntry) = apply {
+        positionalFields += recordEntries
+    }
+
+    /**
+     * Adds an anonymous positional field to the record type.
+     * @param typeName the [TypeName] of the positional field
+     * @return the current builder instance
+     */
+    fun positional(typeName: TypeName) = positional(RecordEntry(typeName))
+
+    /**
+     * Adds a labeled positional field to the record type.
+     * @param typeName the [TypeName] of the positional field
+     * @param name the descriptive label of the positional field
+     * @return the current builder instance
+     */
+    fun positional(typeName: TypeName, name: String) = positional(RecordEntry(typeName, name))
+
+    /**
+     * Adds an anonymous positional field from a [KClass] to the record type.
+     * @param type of the positional field
+     * @return the current builder instance
+     */
+    fun positional(type: KClass<*>) = positional(type.asTypeName())
+
+    /**
+     * Adds a labeled positional field from a [KClass] to the record type.
+     * @param type of the positional field
+     * @param name the descriptive label of the positional field
+     * @return the current builder instance
+     */
+    fun positional(type: KClass<*>, name: String) = positional(type.asTypeName(), name)
+
+    /**
+     * Adds multiple anonymous positional fields to the record type.
+     * @param types of the positional fields
+     * @return the current builder instance
+     */
+    fun positional(vararg types: TypeName) = apply {
+        types.forEach { positional(it) }
+    }
+
+    /**
+     * Adds multiple anonymous positional fields from [KClass] instances to the record type.
+     * @param types the types of the positional fields as [KClass]
+     * @return the current builder instance
+     */
+    fun positional(vararg types: KClass<*>) = apply {
+        types.forEach { positional(it) }
+    }
+
+    /**
+     * Adds a named [RecordEntry] to the record type.
+     * @param recordEntry the entry to add
+     * @return the current builder instance
+     */
+    fun named(recordEntry: RecordEntry) = apply {
+        namedFields += recordEntry
+    }
+
+    /**
+     * Adds multiple named [RecordEntry] instances to the record type.
+     * @param recordEntries the entries to add
+     * @return the current builder instance
+     */
+    fun named(vararg recordEntries: RecordEntry) = apply {
+        namedFields += recordEntries
+    }
+
+    /**
+     * Adds a named field with the given [name] and [typeName] to the record type.
+     * @param name of the field
+     * @param typeName of the field
+     * @return the current builder instance
+     */
+    fun named(name: String, typeName: TypeName) = named(RecordEntry(typeName, name))
+
+    /**
+     * Adds a named field with the given [name] and [type] to the record type.
+     * @param name of the field
+     * @param type of the field
+     * @return the current builder instance
+     */
+    fun named(name: String, type: KClass<*>) = named(RecordEntry(type.asTypeName(), name))
+
+    /**
+     * Sets whether the record type itself is nullable.
+     * @param nullable whether the record type can be null (default is true)
+     * @return the current builder instance
+     */
+    fun nullable(nullable: Boolean = true) = apply {
+        this.isNullable = nullable
+    }
+
+    /**
+     * Creates a new [RecordTypeName] using the configured fields and nullability.
+     * @return the created [RecordTypeName] instance
+     */
+    fun build(): RecordTypeName = RecordTypeName(
+        positionalFields = positionalFields.toImmutableList(),
+        namedFields = namedFields.toImmutableList(),
+        isNullable = isNullable
+    )
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/type/record/RecordTypeName.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/type/record/RecordTypeName.kt
@@ -1,0 +1,119 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.type.record.RecordEntry
+import net.theevilreaper.dartpoet.util.EMPTY_STRING
+import net.theevilreaper.dartpoet.util.RecordHelper
+import net.theevilreaper.dartpoet.util.toImmutableList
+import kotlin.reflect.KClass
+
+/**
+ * Represents a Dart 3 record type name such as `(int, String)`, `({int a, String b})`, or `(int, {String name})?`.
+ *
+ * Record types support positional fields (with optional descriptive labels) and named fields enclosed in `{}`.
+ * In Dart 3, single positional record types require a trailing comma `(int,)` to distinguish them from parenthesized types.
+ *
+ * @param positionalFields the positional fields of the record type
+ * @param namedFields the named fields of the record type
+ * @param isNullable whether the record type itself can be null (default is false)
+ * @since 2.3.0
+ * @author theEvilReaper
+ */
+class RecordTypeName internal constructor(
+    val positionalFields: List<RecordEntry>,
+    val namedFields: List<RecordEntry>,
+    isNullable: Boolean = false,
+) : TypeName(
+    isNullable = isNullable
+) {
+
+    init {
+        require(namedFields.all { !it.name.isNullOrBlank() }) {
+            "All named fields in a record must have a non-blank name"
+        }
+
+        val duplicateNamed = namedFields.groupBy { it.name }.filter { it.value.size > 1 }.keys
+        require(duplicateNamed.isEmpty()) {
+            "Duplicate named field names are not allowed: $duplicateNamed"
+        }
+
+        require(namedFields.none { it.name?.startsWith("_") == true }) {
+            "Record field names cannot be private (start with '_')"
+        }
+
+        require(positionalFields.none { it.name?.startsWith("_") == true }) {
+            "Record field names cannot be private (start with '_')"
+        }
+
+        require(namedFields.none { it.name in RESERVED_RECORD_MEMBER_NAMES }) {
+            "Record field names cannot use reserved Object member names ($RESERVED_RECORD_MEMBER_NAMES)"
+        }
+
+        require(positionalFields.all { it.name == null || it.name.isNotBlank() }) {
+            "Positional field names cannot be blank"
+        }
+    }
+
+    /**
+     * Emits the record type structure to the given [CodeWriter].
+     * @param out the [CodeWriter] instance to append the generated code into
+     * @return the same [CodeWriter] instance for method chaining
+     */
+    override fun emit(out: CodeWriter): CodeWriter {
+        return RecordHelper.writeRecord(positionalFields, namedFields, isNullable, out)
+    }
+
+    /**
+     * Returns the raw data from a [RecordTypeName] instance.
+     */
+    override fun getRawData(): String = EMPTY_STRING
+
+    /**
+     * Creates a copy of this [RecordTypeName] with an optional nullable flag.
+     * @param nullable whether the copied [RecordTypeName] should be nullable
+     * @return a new [RecordTypeName] instance with the specified nullable flag
+     */
+    override fun copy(nullable: Boolean): RecordTypeName = RecordTypeName(positionalFields, namedFields, nullable)
+
+    /**
+     * Creates a [RecordTypeBuilder] initialized with the fields and nullability of this [RecordTypeName].
+     * @return a [RecordTypeBuilder] populated with this record type's data
+     */
+    fun toBuilder(): RecordTypeBuilder {
+        val builder = RecordTypeBuilder()
+        builder.positionalFields.addAll(positionalFields)
+        builder.namedFields.addAll(namedFields)
+        builder.isNullable = isNullable
+        return builder
+    }
+
+    companion object {
+
+        private val RESERVED_RECORD_MEMBER_NAMES = setOf("hashCode", "runtimeType", "noSuchMethod", "toString")
+
+        /**
+         * Creates a new [RecordTypeBuilder] instance.
+         * @return the created builder
+         */
+        @JvmStatic
+        fun builder() = RecordTypeBuilder()
+
+        /**
+         * Creates a [RecordTypeName] with the provided positional [types].
+         * @param types the positional types of the record
+         * @return the created [RecordTypeName]
+         */
+        @JvmStatic
+        fun of(vararg types: TypeName): RecordTypeName =
+            builder().apply { types.forEach { positional(it) } }.build()
+
+        /**
+         * Creates a [RecordTypeName] with the provided positional [types] converted from [KClass].
+         * @param types the positional types of the record as [KClass]
+         * @return the created [RecordTypeName]
+         */
+        @JvmStatic
+        fun of(vararg types: KClass<*>): RecordTypeName =
+            builder().apply { types.forEach { positional(it) } }.build()
+    }
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/util/RecordHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/util/RecordHelper.kt
@@ -1,0 +1,79 @@
+package net.theevilreaper.dartpoet.util
+
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.type.record.RecordEntry
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * The [RecordHelper] contains utility methods to write Dart 3 record types.
+ *
+ * @since 2.3.0
+ * @author theEvilReaper
+ */
+@ApiStatus.Internal
+internal object RecordHelper {
+
+    /**
+     * Writes the given record components to the [CodeWriter].
+     *
+     * @param positionalFields the list of positional fields in the record
+     * @param namedFields the list of named fields in the record
+     * @param isNullable whether the record type itself is nullable
+     * @param out the [CodeWriter] to write to
+     * @return the [CodeWriter] instance
+     */
+    fun writeRecord(
+        positionalFields: List<RecordEntry>,
+        namedFields: List<RecordEntry>,
+        isNullable: Boolean,
+        out: CodeWriter,
+    ): CodeWriter {
+        out.emit(ROUND_OPEN)
+
+        val hasPositional = positionalFields.isNotEmpty()
+        val hasNamed = namedFields.isNotEmpty()
+
+        if (hasPositional) {
+            positionalFields.forEachIndexed { index, field ->
+                field.typeName.emit(out)
+                if (!field.name.isNullOrBlank()) {
+                    out.emitSpace()
+                    out.emit(field.name)
+                }
+                if (index < positionalFields.size - 1) {
+                    out.emit(COMMA_SEPARATOR)
+                }
+            }
+
+            // Single positional field without named fields requires a trailing comma in Dart 3: (int,)
+            if (positionalFields.size == 1 && !hasNamed) {
+                out.emit(",")
+            }
+        }
+
+        if (hasPositional && hasNamed) {
+            out.emit(COMMA_SEPARATOR)
+        }
+
+        if (hasNamed) {
+            out.emit(CURLY_OPEN.toString())
+            namedFields.forEachIndexed { index, field ->
+                field.typeName.emit(out)
+                out.emitSpace()
+                out.emit(field.name ?: EMPTY_STRING)
+                if (index < namedFields.size - 1) {
+                    out.emit(COMMA_SEPARATOR)
+                }
+            }
+            out.emit(CURLY_CLOSE.toString())
+        }
+
+        out.emit(ROUND_CLOSE)
+
+        if (isNullable) {
+            out.emit(NULLABLE_CHAR)
+        }
+
+        return out
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/type/RecordCorpusTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/type/RecordCorpusTest.kt
@@ -1,0 +1,253 @@
+package net.theevilreaper.dartpoet.corpus
+
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.function.typedef.TypeDef
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.DOUBLE
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.type.RecordTypeName
+import net.theevilreaper.dartpoet.type.STRING
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Corpus tests for Dart 3 record types verified against the Dart analyzer")
+class RecordCorpusTest {
+
+    @Test
+    fun `test top level record properties in a Dart file`() {
+        val file = DartFile.builder("record_properties")
+            .property(
+                PropertySpec.builder("pair", RecordTypeName.of(INTEGER, STRING))
+                    .modifier { DartModifier.FINAL }
+                    .initWith("%L", "(1, 'hello')")
+                    .build()
+            )
+            .property(
+                PropertySpec.builder(
+                    "user",
+                    RecordTypeName.builder().named("id", INTEGER).named("name", STRING).build()
+                )
+                    .modifier { DartModifier.FINAL }
+                    .initWith("%L", "(id: 42, name: 'Alice')")
+                    .build()
+            )
+            .property(
+                PropertySpec.builder("single", RecordTypeName.of(INTEGER))
+                    .modifier { DartModifier.FINAL }
+                    .initWith("%L", "(1,)")
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("main")
+                    .addCode("print(pair);\nprint(user);\nprint(single);")
+                    .build()
+            )
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |final (int, String) pair = (1, 'hello');
+            |final ({int id, String name}) user = (id: 42, name: 'Alice');
+            |final (int,) single = (1,);
+            |
+            |void main() {
+            |  print(pair);
+            |  print(user);
+            |  print(single);
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test functions with record parameters and return types`() {
+        val swapFunction = FunctionSpec.builder("swap")
+            .returns(RecordTypeName.of(INTEGER, STRING))
+            .parameter(ParameterSpec.positional("a", STRING).build())
+            .parameter(ParameterSpec.positional("b", INTEGER).build())
+            .addCode("return (b, a);")
+            .build()
+
+        val calcFunction = FunctionSpec.builder("calculate")
+            .returns(
+                RecordTypeName.builder()
+                    .named("sum", INTEGER)
+                    .named("diff", INTEGER)
+                    .build()
+            )
+            .parameter(ParameterSpec.positional("a", INTEGER).build())
+            .parameter(ParameterSpec.positional("b", INTEGER).build())
+            .addCode("return (sum: a + b, diff: a - b);")
+            .build()
+
+        val file = DartFile.builder("record_functions")
+            .function(swapFunction)
+            .function(calcFunction)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |(int, String) swap(String a, int b) {
+            |  return (b, a);
+            |}
+            |
+            |({int sum, int diff}) calculate(int a, int b) {
+            |  return (sum: a + b, diff: a - b);
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test class containing record properties and methods`() {
+        val coordsType = RecordTypeName.builder()
+            .positional(DOUBLE, "lat")
+            .positional(DOUBLE, "lng")
+            .build()
+
+        val clazz = ClassSpec.builder("Location")
+            .property(
+                PropertySpec.builder("coordinates", coordsType)
+                    .modifier { DartModifier.FINAL }
+                    .build()
+            )
+            .constructor(
+                ConstructorSpec.builder("Location")
+                    .parameters(ParameterSpec.positional("coordinates").build())
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("getRawCoords")
+                    .returns(RecordTypeName.of(DOUBLE, DOUBLE))
+                    .addCode("return coordinates;")
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("location_model")
+            .type(clazz)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |class Location {
+            |
+            |  final (double lat, double lng) coordinates;
+            |
+            |  Location(this.coordinates);
+            |
+            |  (double, double) getRawCoords() {
+            |    return coordinates;
+            |  }
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test file with record typedefs and parameterized collections`() {
+        val point3dTypeDef = TypeDef.alias("Point3D")
+            .returns(
+                RecordTypeName.builder()
+                    .named("x", DOUBLE)
+                    .named("y", DOUBLE)
+                    .named("z", DOUBLE)
+                    .build()
+            )
+            .build()
+
+        val listProperty = PropertySpec.builder(
+            "indexedItems",
+            ClassName("List").parameterizedBy(RecordTypeName.of(INTEGER, STRING))
+        )
+            .modifier { DartModifier.FINAL }
+            .initWith("%L", "<(int, String)>[(1, 'one'), (2, 'two')]")
+            .build()
+
+        val file = DartFile.builder("record_typedefs")
+            .typeDef(point3dTypeDef)
+            .property(listProperty)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |typedef Point3D = ({double x, double y, double z});
+            |
+            |final List<(int, String)> indexedItems = <(int, String)>[(1, 'one'), (2, 'two')];
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test standalone record properties`() {
+        val positionalProp = PropertySpec.builder("pair", RecordTypeName.of(INTEGER, STRING))
+            .modifier { DartModifier.LATE }
+            .build()
+        positionalProp.verifyDartOutput("late (int, String) pair;")
+
+        val singleProp = PropertySpec.builder("single", RecordTypeName.of(INTEGER))
+            .modifier { DartModifier.LATE }
+            .build()
+        singleProp.verifyDartOutput("late (int,) single;")
+
+        val namedProp = PropertySpec.builder(
+            "point",
+            RecordTypeName.builder().named("x", DOUBLE).named("y", DOUBLE).build()
+        )
+            .modifier { DartModifier.LATE }
+            .build()
+        namedProp.verifyDartOutput("late ({double x, double y}) point;")
+
+        val mixedNullableProp = PropertySpec.builder(
+            "userTuple",
+            RecordTypeName.builder().positional(INTEGER, "id").named("name", STRING).nullable().build()
+        ).build()
+        mixedNullableProp.verifyDartOutput("(int id, {String name})? userTuple;")
+    }
+
+    @Test
+    fun `test standalone external functions with records`() {
+        val returningRecord = FunctionSpec.builder("getCoordinates")
+            .modifiers(DartModifier.EXTERNAL)
+            .returns(RecordTypeName.builder().positional(DOUBLE, "lat").positional(DOUBLE, "lng").build())
+            .build()
+        returningRecord.verifyDartOutput("external (double lat, double lng) getCoordinates();")
+
+        val takingRecord = FunctionSpec.builder("registerUser")
+            .modifiers(DartModifier.EXTERNAL)
+            .parameter(
+                ParameterSpec.positional(
+                    "info",
+                    RecordTypeName.builder().named("name", STRING).named("age", INTEGER).build()
+                ).build()
+            )
+            .build()
+        takingRecord.verifyDartOutput("external void registerUser(({String name, int age}) info);")
+    }
+
+    @Test
+    fun `test standalone record typedefs`() {
+        val pairTypeDef = TypeDef.alias("Pair")
+            .returns(RecordTypeName.of(INTEGER, STRING))
+            .build()
+        pairTypeDef.verifyDartOutput("typedef Pair = (int, String);")
+
+        val userRecordTypeDef = TypeDef.alias("UserRecord")
+            .returns(
+                RecordTypeName.builder().named("id", INTEGER).named("name", STRING).build()
+            )
+            .build()
+        userRecordTypeDef.verifyDartOutput("typedef UserRecord = ({int id, String name});")
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/type/RecordTypeNameTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/type/RecordTypeNameTest.kt
@@ -1,0 +1,226 @@
+package net.theevilreaper.dartpoet.type
+
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.type.record.RecordEntry
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@DisplayName("Test cases for the RecordTypeName implementation")
+class RecordTypeNameTest {
+
+    companion object {
+
+        private val LIST = ClassName("List")
+
+        @JvmStatic
+        private fun recordTypeNames() = Stream.of(
+            Arguments.of(
+                "()",
+                RecordTypeName.builder().build()
+            ),
+            Arguments.of(
+                "(int,)",
+                RecordTypeName.of(INTEGER)
+            ),
+            Arguments.of(
+                "(int count,)",
+                RecordTypeName.builder().positional(INTEGER, "count").build()
+            ),
+            Arguments.of(
+                "(int, String)",
+                RecordTypeName.of(INTEGER, STRING)
+            ),
+            Arguments.of(
+                "(int id, String name)",
+                RecordTypeName.builder()
+                    .positional(INTEGER, "id")
+                    .positional(STRING, "name")
+                    .build()
+            ),
+            Arguments.of(
+                "({int a})",
+                RecordTypeName.builder().named("a", INTEGER).build()
+            ),
+            Arguments.of(
+                "({int a, String b})",
+                RecordTypeName.builder()
+                    .named("a", INTEGER)
+                    .named("b", STRING)
+                    .build()
+            ),
+            Arguments.of(
+                "(int, {String name})",
+                RecordTypeName.builder()
+                    .positional(INTEGER)
+                    .named("name", STRING)
+                    .build()
+            ),
+            Arguments.of(
+                "(int id, String tag, {bool active, double score})",
+                RecordTypeName.builder()
+                    .positional(INTEGER, "id")
+                    .positional(STRING, "tag")
+                    .named("active", BOOLEAN)
+                    .named("score", DOUBLE)
+                    .build()
+            ),
+            Arguments.of(
+                "(int, String)?",
+                RecordTypeName.builder()
+                    .positional(INTEGER, STRING)
+                    .nullable()
+                    .build()
+            ),
+            Arguments.of(
+                "(int,)?",
+                RecordTypeName.builder()
+                    .positional(INTEGER)
+                    .nullable()
+                    .build()
+            ),
+            Arguments.of(
+                "({int a, String b})?",
+                RecordTypeName.builder()
+                    .named("a", INTEGER)
+                    .named("b", STRING)
+                    .nullable()
+                    .build()
+            ),
+            Arguments.of(
+                "(int, (String, bool))",
+                RecordTypeName.builder()
+                    .positional(INTEGER)
+                    .positional(RecordTypeName.of(STRING, BOOLEAN))
+                    .build()
+            ),
+        )
+    }
+
+    @ParameterizedTest(name = "Test creation of: {0}")
+    @MethodSource("recordTypeNames")
+    fun `test record type name write`(expected: String, recordType: RecordTypeName) {
+        assertEquals(expected, recordType.toString())
+    }
+
+    @Test
+    fun `test record type through property writer`() {
+        val property = PropertySpec.builder(
+            "pair",
+            RecordTypeName.of(INTEGER, STRING)
+        ).build()
+        assertEquals("(int, String) pair;", property.toString())
+    }
+
+    @Test
+    fun `test nullable record type through property writer`() {
+        val property = PropertySpec.builder(
+            "maybeTuple",
+            RecordTypeName.builder()
+                .positional(INTEGER)
+                .named("name", STRING)
+                .nullable()
+                .build()
+        ).build()
+        assertEquals("(int, {String name})? maybeTuple;", property.toString())
+    }
+
+    @Test
+    fun `test record type in parameterized type`() {
+        val listType = LIST.parameterizedBy(RecordTypeName.of(INTEGER, STRING))
+        assertEquals("List<(int, String)>", listType.toString())
+    }
+
+    @Test
+    fun `test record type from kotlin classes`() {
+        val record = RecordTypeName.of(Int::class, String::class)
+        assertEquals("(int, String)", record.toString())
+    }
+
+    @Test
+    fun `test equals and hashCode for record type name`() {
+        val first = RecordTypeName.of(INTEGER, STRING)
+        val second = RecordTypeName.of(INTEGER, STRING)
+        val third = RecordTypeName.of(STRING, INTEGER)
+
+        assertEquals(first, second)
+        assertEquals(first.hashCode(), second.hashCode())
+        assertNotEquals(first, third)
+    }
+
+    @Test
+    fun `test copy method from the record type name`() {
+        val record = RecordTypeName.of(INTEGER, STRING)
+        assertFalse(record.isNullable)
+        val nullableRecord = record.copy(nullable = true)
+        assertTrue(nullableRecord.isNullable)
+        assertEquals("(int, String)?", nullableRecord.toString())
+    }
+
+    @Test
+    fun `test toBuilder from the record type name`() {
+        val original = RecordTypeName.of(INTEGER)
+        val modified = original.toBuilder()
+            .positional(STRING)
+            .named("extra", BOOLEAN)
+            .build()
+        assertEquals("(int, String, {bool extra})", modified.toString())
+    }
+
+    @Test
+    fun `test builder throws for blank named field name`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            RecordTypeName.builder()
+                .named(RecordEntry(INTEGER, "   "))
+                .build()
+        }
+        assertEquals("All named fields in a record must have a non-blank name", exception.message)
+    }
+
+    @Test
+    fun `test builder throws for duplicate named field names`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            RecordTypeName.builder()
+                .named("foo", INTEGER)
+                .named("foo", STRING)
+                .build()
+        }
+        assertTrue(exception.message!!.contains("Duplicate named field names are not allowed"))
+    }
+
+    @Test
+    fun `test builder throws for private named field names`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            RecordTypeName.builder()
+                .named("_privateField", INTEGER)
+                .build()
+        }
+        assertEquals("Record field names cannot be private (start with '_')", exception.message)
+    }
+
+    @Test
+    fun `test builder throws for private positional field names`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            RecordTypeName.builder()
+                .positional(INTEGER, "_privateLabel")
+                .build()
+        }
+        assertEquals("Record field names cannot be private (start with '_')", exception.message)
+    }
+
+    @Test
+    fun `test builder throws for reserved object member names in named fields`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            RecordTypeName.builder()
+                .named("hashCode", INTEGER)
+                .build()
+        }
+        assertTrue(exception.message!!.contains("Record field names cannot use reserved Object member names"))
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds native support for Dart 3 record types including positional and named fields. Provides a fluent builder API with proper nullability handling and formatting. Includes validation for Dart 3 specification rules and full analyzer verification.

Closes #214 and #215 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)