### PR TITLE
fix(file): allow generated files to reference other folders in the same project

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFile.kt
@@ -25,8 +25,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 class DartFile internal constructor(
-    builder: DartFileBuilder,
-    val maxDepth: Int = DEFAULT_MAX_DEPTH
+    builder: DartFileBuilder
 ) {
     internal val name: String = builder.name
     internal val indent: String = builder.indent
@@ -81,18 +80,33 @@ class DartFile internal constructor(
 
     /**
      * Writes the content from a [DartFile] to the given [Path].
+     *
+     * [baseDir] is the directory that relative imports (`../`) must not escape. It defaults to
+     * [path] itself, matching the previous behaviour where the write target was also the security
+     * boundary. Pass an ancestor of [path] explicitly when the file is written into a subdirectory
+     * of the actual project root but still needs to reference sibling directories via a relative
+     * import, e.g.:
+     *
+     * ```kotlin
+     * // lib/enchantment/armor_enchantment.dart importing lib/api/enchantment.dart
+     * dartFile.write(libRoot.resolve("enchantment"), baseDir = libRoot)
+     * ```
+     *
      * @param path the path where the file should be written
+     * @param baseDir the directory relative imports must stay within; defaults to [path]
      * @throws IOException if the file can't be written
+     * @throws IllegalArgumentException if [path] is not located inside [baseDir]
      */
     @Throws(IOException::class)
-    fun write(path: Path) {
+    @JvmOverloads
+    fun write(path: Path, baseDir: Path = path) {
         require(Files.notExists(path) || Files.isDirectory(path)) {
             "The given path $path exists but it is not a directory"
         }
 
         require(isDartConventionFileName(name)) {
             """
-             The given name $name has some issues with the naming   
+             The given name $name has some issues with the naming
              Please take a look at this page https://dart.dev/tools/linter-rules#file_names
             """.trimIndent()
         }
@@ -104,15 +118,21 @@ class DartFile internal constructor(
 
         PathValidation.validateFileName(fileName)
 
+        val normalizedTargetDir = path.toAbsolutePath().normalize()
+        val normalizedBaseDir = baseDir.toAbsolutePath().normalize()
+
+        require(normalizedTargetDir.startsWith(normalizedBaseDir)) {
+            "The write target '$normalizedTargetDir' must be located inside baseDir '$normalizedBaseDir'"
+        }
+
         val pathToWrite = path.resolve(fileName).normalize()
 
-        require(pathToWrite.startsWith(path.toAbsolutePath().normalize())) {
+        require(pathToWrite.startsWith(normalizedTargetDir)) {
             "Resolved file path '$pathToWrite' would be outside target directory '$path'"
         }
 
         if (relativeImports.isNotEmpty()) {
-            val normalizedPath = path.toAbsolutePath().normalize()
-            PathValidation.validateRelativeImports(relativeImports, normalizedPath, pathToWrite)
+            PathValidation.validateRelativeImports(relativeImports, normalizedBaseDir, pathToWrite)
         }
 
         OutputStreamWriter(Files.newOutputStream(pathToWrite), Charsets.UTF_8)
@@ -144,7 +164,7 @@ class DartFile internal constructor(
 
         /**
          * Creates a new instance from an [DartFileBuilder] to create class structures.
-         * @param name the name which is used for the dart file
+         * @param name the name that is used for the Dart file
          * @return the created instance from the [DartFileBuilder] instance
          */
         @JvmStatic

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileWriteBaseDirTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileWriteBaseDirTest.kt
@@ -1,0 +1,85 @@
+package net.theevilreaper.dartpoet
+
+import com.google.common.truth.Truth.assertThat
+import net.theevilreaper.dartpoet.directive.DirectiveFactory
+import net.theevilreaper.dartpoet.directive.DirectiveType
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+@DisplayName("Test DartFile#write(path, baseDir) with relative imports across sibling directories")
+class DartFileWriteBaseDirTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `write into subdirectory with explicit baseDir allows sibling import`() {
+        val libRoot = tempDir.resolve("lib")
+        val enchantmentDir = libRoot.resolve("enchantment")
+        Files.createDirectories(enchantmentDir)
+
+        val dartFile = DartFile.builder("armor_enchantment")
+            .directive(DirectiveFactory.create(DirectiveType.RELATIVE, "../api/enchantment"))
+            .build()
+
+        dartFile.write(enchantmentDir, baseDir = libRoot)
+
+        val writtenFile = enchantmentDir.resolve("armor_enchantment.dart")
+        assertThat(Files.exists(writtenFile)).isTrue()
+        assertThat(Files.readString(writtenFile)).contains("import '../api/enchantment';")
+    }
+
+    @Test
+    fun `write into subdirectory without baseDir keeps previous strict behaviour`() {
+        val libRoot = tempDir.resolve("lib")
+        val enchantmentDir = libRoot.resolve("enchantment")
+        Files.createDirectories(enchantmentDir)
+
+        val dartFile = DartFile.builder("armor_enchantment")
+            .directive(DirectiveFactory.create(DirectiveType.RELATIVE, "../api/enchantment"))
+            .build()
+
+        // baseDir defaults to the write target itself, matching pre-patch behaviour:
+        // this import legitimately escapes `enchantmentDir`, so it must still fail.
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            dartFile.write(enchantmentDir)
+        }
+        assertThat(exception.message).contains("outside project directory")
+    }
+
+    @Test
+    fun `write rejects a baseDir that is not an ancestor of the write target`() {
+        val libRoot = tempDir.resolve("lib")
+        val unrelatedDir = tempDir.resolve("other")
+        Files.createDirectories(unrelatedDir)
+        Files.createDirectories(libRoot)
+
+        val dartFile = DartFile.builder("armor_enchantment")
+            .build()
+
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            dartFile.write(unrelatedDir, baseDir = libRoot)
+        }
+        assertThat(exception.message).contains("must be located inside baseDir")
+    }
+
+    @Test
+    fun `write still rejects imports escaping the wider baseDir`() {
+        val libRoot = tempDir.resolve("lib")
+        val enchantmentDir = libRoot.resolve("enchantment")
+        Files.createDirectories(enchantmentDir)
+
+        val dartFile = DartFile.builder("armor_enchantment")
+            .directive(DirectiveFactory.create(DirectiveType.RELATIVE, "../../outside"))
+            .build()
+
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            dartFile.write(enchantmentDir, baseDir = libRoot)
+        }
+        assertThat(exception.message).contains("outside project directory")
+    }
+}


### PR DESCRIPTION
## Proposed changes

Generated files that lived in a subfolder couldn't correctly reference other parts of the same project, even when the reference was perfectly valid. Saving a file now lets you specify the actual project folder separately from the folder it's written into, so those valid references work. Protection against files pointing outside the project is untouched. Also removed an old unused setting that had no effect.  

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)