### PR TITLE
fix(directive): append .dart extension to relative imports

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/BaseDirective.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/BaseDirective.kt
@@ -52,7 +52,7 @@ abstract class BaseDirective(
      * @return true when the path starts with the word otherwise false
      */
     private fun isDartImport(): Boolean {
-        return path.startsWith("dart")
+        return path.startsWith("dart:")
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/DirectiveHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/DirectiveHelper.kt
@@ -136,18 +136,18 @@ internal object DirectiveHelper {
      * @return the input with an indication dot as a prefix
      */
     private fun updateRelativeImportBegin(directive: RelativeDirective): String {
-        val rawPath = directive.getRawPath()
+        val path = directive.getPathWithEnding()
 
         // If a path already has ../, return as-is (user already provided the dots)
-        if (rawPath.startsWith("../")) {
-            return rawPath
+        if (path.startsWith("../")) {
+            return path
         }
 
         // Otherwise add based on depth
         return when (directive.depth) {
-            0 -> rawPath // No prefix needed
-            1 -> "$RELATIVE_DOTS$rawPath"
-            else -> "${RELATIVE_DOTS.repeat(directive.depth)}$rawPath"
+            0 -> path // No prefix needed
+            1 -> "$RELATIVE_DOTS$path"
+            else -> "${RELATIVE_DOTS.repeat(directive.depth)}$path"
         }
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/DartFileWriteBaseDirTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/DartFileWriteBaseDirTest.kt
@@ -30,7 +30,7 @@ class DartFileWriteBaseDirTest {
 
         val writtenFile = enchantmentDir.resolve("armor_enchantment.dart")
         assertThat(Files.exists(writtenFile)).isTrue()
-        assertThat(Files.readString(writtenFile)).contains("import '../api/enchantment';")
+        assertThat(Files.readString(writtenFile)).contains("import '../api/enchantment.dart';")
     }
 
     @Test

--- a/src/test/kotlin/net/theevilreaper/dartpoet/directive/RelativeDirectiveTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/directive/RelativeDirectiveTest.kt
@@ -66,6 +66,41 @@ class RelativeDirectiveTest {
                 DirectiveFactory.createRelative(TEST_IMPORT, CastType.SHOW, CAST_VALUE),
                 "import '../model/item_model.dart' show item;",
                 1
+            ),
+            Arguments.of(
+                DirectiveFactory.create(DirectiveType.RELATIVE, "../path/to/file"),
+                "import '../path/to/file.dart';",
+                1
+            ),
+            Arguments.of(
+                DirectiveFactory.create(DirectiveType.RELATIVE, "path/to/file"),
+                "import '../path/to/file.dart';",
+                1
+            ),
+            Arguments.of(
+                DirectiveFactory.create(DirectiveType.RELATIVE, "../dart_helper/utils"),
+                "import '../dart_helper/utils.dart';",
+                1
+            ),
+            Arguments.of(
+                DirectiveFactory.create(DirectiveType.RELATIVE, "dart_helper/utils"),
+                "import '../dart_helper/utils.dart';",
+                1
+            ),
+            Arguments.of(
+                DirectiveFactory.createRelative("path/to/file", depth = 2),
+                "import '../../path/to/file.dart';",
+                2
+            ),
+            Arguments.of(
+                DirectiveFactory.create(
+                    DirectiveType.RELATIVE,
+                    "../api/enchantment",
+                    CastType.AS,
+                    "enchantment"
+                ),
+                "import '../api/enchantment.dart' as enchantment;",
+                1
             )
         )
 
@@ -94,7 +129,7 @@ class RelativeDirectiveTest {
         val currentImportString = current.asString()
         assertEquals(expected, currentImportString)
         val prefixCount = countRelativeSegments(currentImportString)
-        assertEquals(depth, prefixCount, "There should be exactly two dot prefix")
+        assertEquals(depth, prefixCount, "There should be exactly $depth dot prefix")
     }
 
     @ParameterizedTest(name = "Sanitize invalid prefix: {0} with depth {1}")
@@ -132,7 +167,6 @@ class RelativeDirectiveTest {
         assertInstanceOf(RelativeDirective::class.java, import)
 
         val importAsString = import.asString()
-        println(importAsString)
         assertNotNull(importAsString, "The import should not be null")
 
         val prefixCount = countRelativeSegments(importAsString)
@@ -150,7 +184,7 @@ class RelativeDirectiveTest {
         val importAsString = relativeImport.asString()
 
         val prefixCount = countRelativeSegments(importAsString)
-        assertEquals(4, prefixCount, "There should be exactly two dot prefix")
+        assertEquals(4, prefixCount, "There should be exactly 4 dot prefix")
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Relative import directives previously omitted the `.dart` file extension when created without one, causing resolution errors in the Dart analyzer and compiler. This PR ensures that relative imports automatically append the `.dart` extension if missing, while leaving paths that already specify it unaffected. Additionally, paths starting with the word "dart" are no longer falsely classified as Dart SDK imports. Corresponding unit tests have been consolidated and expanded to verify all relative import variations.

Fixes #303

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)