### PR TITLE
fix(directive): improve consistency across directive implementations

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/BaseDirective.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/BaseDirective.kt
@@ -34,7 +34,9 @@ abstract class BaseDirective(
     /**
      * Makes a comparison with two [Directive] implementation over a [Comparable]
      */
-    override fun compareTo(other: Directive): Int = asString().compareTo(other.toString())
+    override fun compareTo(other: Directive): Int = asString().compareTo(other.asString())
+
+    override fun toString(): String = asString()
 
     /**
      * Ensures that the directive path ends with .dart.

--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/DirectiveHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/DirectiveHelper.kt
@@ -100,9 +100,14 @@ internal object DirectiveHelper {
             else -> Pair(getLibraryImportKey(asPartOf), "%L")
         }
 
+        val path = when (directive.type()) {
+            DirectiveType.PART -> directive.getPathWithEnding()
+            else -> directive.getRawPath()
+        }
+
         writer.emitCode("%L", importPair.first)
         writer.emitSpace()
-        writer.emitCode(importPair.second, directive.getRawPath())
+        writer.emitCode(importPair.second, path)
         writer.emit(SEMICOLON)
     }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/impl/PackageDirective.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/impl/PackageDirective.kt
@@ -23,9 +23,7 @@ class PackageDirective internal constructor(
 ): BaseDirective(DirectiveType.PACKAGE, path) {
 
     init {
-        require((castType == null) == (importCast == null)) {
-            "castType and importCast must be both null or both non-null."
-        }
+        DirectiveHelper.validateCast(importCast, castType)
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/directive/impl/RelativeDirective.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/directive/impl/RelativeDirective.kt
@@ -28,9 +28,7 @@ class RelativeDirective internal constructor(
         val decoded: String? = URLDecoder.decode(path, StandardCharsets.UTF_8)
         require(path == decoded) { "The path $path contains invalid characters" }
 
-        check((castType == null) == (importCast == null)) {
-            "The castType and importCast must be set together or must be null. A mixed state is not allowed"
-        }
+        DirectiveHelper.validateCast(importCast, castType)
     }
 
     /**

--- a/src/test/kotlin/net/theevilreaper/dartpoet/directive/DirectiveTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/directive/DirectiveTest.kt
@@ -4,6 +4,7 @@ import net.theevilreaper.dartpoet.directive.impl.*
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
 import net.theevilreaper.dartpoet.util.SPACE_STRING
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -35,7 +36,9 @@ class DirectiveTest {
             Arguments.of({ RelativeDirective("flutter/material.dart", CastType.AS, null) }, INVALID_CAST_USAGE),
             Arguments.of({ RelativeDirective("flutter/material.dart", null, "test") }, INVALID_CAST_USAGE),
             Arguments.of({ ExportDirective("test.dart", CastType.HIDE, null) }, INVALID_CAST_USAGE),
-            Arguments.of({ ExportDirective("test.dart", null, "test") }, INVALID_CAST_USAGE)
+            Arguments.of({ ExportDirective("test.dart", null, "test") }, INVALID_CAST_USAGE),
+            Arguments.of({ PackageDirective("test.dart", CastType.AS, null) }, INVALID_CAST_USAGE),
+            Arguments.of({ PackageDirective("test.dart", null, "test") }, INVALID_CAST_USAGE)
         )
 
         @JvmStatic
@@ -104,5 +107,22 @@ class DirectiveTest {
     fun `test package import`() {
         val import = DirectiveFactory.create(DirectiveType.IMPORT, "flutter/material.dart")
         assertEquals(packageImport, import.asString())
+    }
+
+    @Test
+    fun `test directive compareTo`() {
+        val directiveA = DirectiveFactory.create(DirectiveType.IMPORT, "a.dart")
+        val directiveB = DirectiveFactory.create(DirectiveType.IMPORT, "b.dart")
+        val directiveA2 = DirectiveFactory.create(DirectiveType.IMPORT, "a.dart")
+
+        assertEquals(0, directiveA.compareTo(directiveA2))
+        assertTrue(directiveA < directiveB)
+        assertTrue(directiveB > directiveA)
+    }
+
+    @Test
+    fun `test directive toString matches asString`() {
+        val directive = DirectiveFactory.create(DirectiveType.IMPORT, "flutter/material.dart")
+        assertEquals(directive.asString(), directive.toString())
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/directive/PartDirectiveTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/directive/PartDirectiveTest.kt
@@ -14,4 +14,10 @@ class PartDirectiveTest {
         val partImport = DirectiveFactory.create(DirectiveType.PART, "item_model.freezed.dart")
         assertEquals(expectedImport, partImport.asString())
     }
+
+    @Test
+    fun `create part import without dart extension`() {
+        val partImport = DirectiveFactory.create(DirectiveType.PART, "item_model.freezed")
+        assertEquals(expectedImport, partImport.asString())
+    }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/directive/impl/PackageDirectiveTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/directive/impl/PackageDirectiveTest.kt
@@ -25,7 +25,7 @@ class PackageDirectiveTest {
         castType: CastType?,
         importCast: String?
     ) {
-        val exception = assertThrows(IllegalArgumentException::class.java) {
+        val exception = assertThrows(IllegalStateException::class.java) {
             DirectiveFactory.create(
                 directive = DirectiveType.PACKAGE,
                 path = "my_local_file",
@@ -35,7 +35,7 @@ class PackageDirectiveTest {
         }
 
         assertEquals(
-            "castType and importCast must be both null or both non-null.",
+            "The castType and importCast must be set together or must be null. A mixed state is not allowed",
             exception.message
         )
     }


### PR DESCRIPTION
## Proposed changes

This PR improves consistency across directive implementations by ensuring that part directives automatically append the `.dart` file extension when omitted. It also fixes `BaseDirective.compareTo` to compare against actual directive string representations rather than object memory identities, and adds a matching `toString()` implementation. Additionally, cast validation across relative and package directives is now unified with the central validation logic. Corresponding unit tests have been updated and expanded to cover all changes.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)