### PR TITLE
feat(class): support mixin modifiers

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -37,6 +37,7 @@ class ClassSpec internal constructor(
     internal val isEnum: Boolean = builder.classType == ClassType.ENUM
     internal val isAbstract: Boolean = builder.classType == ClassType.ABSTRACT
     internal val isMixin: Boolean = builder.classType == ClassType.MIXIN
+    internal val isMixinClass: Boolean = builder.classMetaData.modifiers.contains(DartModifier.MIXIN) && (builder.classType == ClassType.CLASS || builder.classType == ClassType.ABSTRACT)
     internal val isAnonymous: Boolean = builder.name == null && builder.classType == ClassType.CLASS
     internal val superClass: TypeName? = builder.superClass
     internal val mixins: List<TypeName> = builder.mixins.toImmutableList()
@@ -77,6 +78,23 @@ class ClassSpec internal constructor(
             }
             check(mixins.isEmpty()) {
                 "A mixin declaration can't use Dart's 'with' clause"
+            }
+            val invalidMixinModifiers = modifiers.intersect(setOf(DartModifier.INTERFACE, DartModifier.FINAL, DartModifier.SEALED))
+            check(invalidMixinModifiers.isEmpty()) {
+                "A mixin can only have the 'base' modifier, but got: $invalidMixinModifiers"
+            }
+        }
+
+        if (isMixinClass) {
+            check(superClass == null) {
+                "A mixin class can't extend a class in Dart"
+            }
+            check(mixins.isEmpty()) {
+                "A mixin class can't use Dart's 'with' clause"
+            }
+            val invalidMixinClassModifiers = modifiers.intersect(setOf(DartModifier.INTERFACE, DartModifier.FINAL, DartModifier.SEALED))
+            check(invalidMixinClassModifiers.isEmpty()) {
+                "A mixin class can only be combined with 'base' or 'abstract', but got: $invalidMixinClassModifiers"
             }
         }
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.dartpoet.code.writer
 
+import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.DartModifier.*
 import net.theevilreaper.dartpoet.clazz.ClassType
 import net.theevilreaper.dartpoet.clazz.ClassSpec
@@ -175,12 +176,15 @@ internal class ClassWriter : Writeable<ClassSpec> {
     private fun writeClassHeader(spec: ClassSpec, writer: CodeWriter) {
         val exclusiveModifier = when (spec.classType) {
             ClassType.CLASS, ClassType.ABSTRACT -> StringHelper.createModifierString(spec.modifiers.filter { it in EXCLUSIVE_CLASS_MODIFIERS })
+            ClassType.MIXIN -> if (DartModifier.BASE in spec.modifiers) "${BASE.identifier} " else EMPTY_STRING
             else -> EMPTY_STRING
         }
 
+        val mixinModifier = if (spec.isMixinClass) "${MIXIN.identifier} " else EMPTY_STRING
+
         val headerPrefix = when (spec.classType) {
-            ClassType.ABSTRACT -> "${ABSTRACT.identifier} $exclusiveModifier${CLASS.identifier}"
-            ClassType.CLASS -> "$exclusiveModifier${CLASS.identifier}"
+            ClassType.ABSTRACT -> "${ABSTRACT.identifier} $exclusiveModifier$mixinModifier${CLASS.identifier}"
+            ClassType.CLASS -> "$exclusiveModifier$mixinModifier${CLASS.identifier}"
             else -> "$exclusiveModifier${spec.classType.keyword}"
         }
 

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassModifierTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/ClassModifierTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import net.theevilreaper.dartpoet.type.ClassName
 import java.util.stream.Stream
 import kotlin.test.assertEquals
 
@@ -44,6 +45,72 @@ class ClassModifierTest {
                         .build()
                 },
                 "A sealed class can't be combined with the abstract modifier because sealed classes are implicitly abstract"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.mixinClass("Handler")
+                        .modifier { DartModifier.INTERFACE }
+                        .build()
+                },
+                "A mixin can only have the 'base' modifier, but got: [INTERFACE]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.mixinClass("Handler")
+                        .modifier { DartModifier.FINAL }
+                        .build()
+                },
+                "A mixin can only have the 'base' modifier, but got: [FINAL]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.mixinClass("Handler")
+                        .modifier { DartModifier.SEALED }
+                        .build()
+                },
+                "A mixin can only have the 'base' modifier, but got: [SEALED]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifiers(DartModifier.MIXIN, DartModifier.INTERFACE)
+                        .build()
+                },
+                "A mixin class can only be combined with 'base' or 'abstract', but got: [INTERFACE]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifiers(DartModifier.MIXIN, DartModifier.FINAL)
+                        .build()
+                },
+                "A mixin class can only be combined with 'base' or 'abstract', but got: [FINAL]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifiers(DartModifier.MIXIN, DartModifier.SEALED)
+                        .build()
+                },
+                "A mixin class can only be combined with 'base' or 'abstract', but got: [SEALED]"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifier { DartModifier.MIXIN }
+                        .superClass(ClassName("Parent"))
+                        .build()
+                },
+                "A mixin class can't extend a class in Dart"
+            ),
+            Arguments.of(
+                {
+                    ClassSpec.builder("Handler")
+                        .modifier { DartModifier.MIXIN }
+                        .withMixins(ClassName("Other"))
+                        .build()
+                },
+                "A mixin class can't use Dart's 'with' clause"
             )
         )
 
@@ -79,7 +146,23 @@ class ClassModifierTest {
             ),
             Arguments.of(
                 ClassSpec.mixinClass("Handler").modifier { DartModifier.BASE }.build(),
-                "mixin Handler {}"
+                "base mixin Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Handler").modifier { DartModifier.MIXIN }.build(),
+                "mixin class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.builder("Handler").modifiers(DartModifier.BASE, DartModifier.MIXIN).build(),
+                "base mixin class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.abstractClass("Handler").modifier { DartModifier.MIXIN }.build(),
+                "abstract mixin class Handler {}"
+            ),
+            Arguments.of(
+                ClassSpec.abstractClass("Handler").modifiers(DartModifier.BASE, DartModifier.MIXIN).build(),
+                "abstract base mixin class Handler {}"
             )
         )
     }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/corpus/ClassModifierCorpusTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/corpus/ClassModifierCorpusTest.kt
@@ -1,0 +1,131 @@
+package net.theevilreaper.dartpoet.corpus
+
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.STRING
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Corpus tests for Dart 3 class and mixin modifiers verified against the Dart analyzer")
+class ClassModifierCorpusTest {
+
+    @Test
+    fun `test Dart 3 base mixin and mixin class declarations in DartFile`() {
+        val baseLogMixin = ClassSpec.mixinClass("BaseLogMixin")
+            .modifier { DartModifier.BASE }
+            .function(
+                FunctionSpec.builder("log")
+                    .parameter(ParameterSpec.positional("msg", STRING).build())
+                    .addCode("// empty body")
+                    .build()
+            )
+            .build()
+
+        val serviceMixinClass = ClassSpec.builder("Service")
+            .modifier { DartModifier.MIXIN }
+            .function(
+                FunctionSpec.builder("start")
+                    .addCode("// start service")
+                    .build()
+            )
+            .build()
+
+        val baseWorkerMixinClass = ClassSpec.builder("BaseWorker")
+            .modifiers(DartModifier.BASE, DartModifier.MIXIN)
+            .function(
+                FunctionSpec.builder("work")
+                    .addCode("// do work")
+                    .build()
+            )
+            .build()
+
+        val abstractHelperMixinClass = ClassSpec.abstractClass("AbstractHelper")
+            .modifier { DartModifier.MIXIN }
+            .function(
+                FunctionSpec.builder("help")
+                    .build()
+            )
+            .build()
+
+        val abstractBaseServiceMixinClass = ClassSpec.abstractClass("AbstractBaseService")
+            .modifiers(DartModifier.BASE, DartModifier.MIXIN)
+            .function(
+                FunctionSpec.builder("init")
+                    .build()
+            )
+            .build()
+
+        val appService = ClassSpec.builder("AppService")
+            .withMixins(ClassName("Service"))
+            .implements(ClassName("AbstractHelper"))
+            .function(
+                FunctionSpec.builder("help")
+                    .annotation(AnnotationSpec.builder("override").build())
+                    .addCode("// help implemented")
+                    .build()
+            )
+            .build()
+
+        val workerApp = ClassSpec.builder("WorkerApp")
+            .modifier { DartModifier.BASE }
+            .superClass(ClassName("BaseWorker"))
+            .withMixins(ClassName("BaseLogMixin"))
+            .build()
+
+        val file = DartFile.builder("class_modifier_corpus")
+            .type(baseLogMixin)
+            .type(serviceMixinClass)
+            .type(baseWorkerMixinClass)
+            .type(abstractHelperMixinClass)
+            .type(abstractBaseServiceMixinClass)
+            .type(appService)
+            .type(workerApp)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |base mixin BaseLogMixin {
+            |
+            |  void log(String msg) {
+            |    // empty body
+            |  }
+            |}
+            |mixin class Service {
+            |
+            |  void start() {
+            |    // start service
+            |  }
+            |}
+            |base mixin class BaseWorker {
+            |
+            |  void work() {
+            |    // do work
+            |  }
+            |}
+            |abstract mixin class AbstractHelper {
+            |
+            |  void help();
+            |}
+            |abstract base mixin class AbstractBaseService {
+            |
+            |  void init();
+            |}
+            |class AppService with Service implements AbstractHelper {
+            |
+            |  @override
+            |  void help() {
+            |    // help implemented
+            |  }
+            |}
+            |base class WorkerApp extends BaseWorker with BaseLogMixin {}
+            |
+            """.trimMargin()
+        )
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds Dart 3 support and validation for:

- `base mixin`
- `mixin class` (including `base`, `abstract` and `abstract base` variants)
- Validation rules (disallow invalid modifier combinations, `extends`, and `with` on mixin classes)
- Corpus tests verified via `dart analyze`

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

As Dart 3 introduces more specialized declaration types, `ClassSpec` and `ClassBuilder` are growing into god-objects with too many conditional checks (`isEnum`, `isMixin`, `isMixinClass`).

**Planned Rework:**

Split declarations into focused, dedicated specs sharing a common `TypeSpec` interface:
- `ClassSpec`: only classes & `mixin class`
- `MixinSpec`: mixins with `on` / `implements` only
- `EnumSpec`: enums with entries only
- `ExtensionTypeSpec`: Dart 3.3 extension types
This avoids runtime validation checks and provides compile-time safety in the respective builders