### PR TITLE
refactor(spec): outsource mixin spec

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
@@ -4,11 +4,9 @@ import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.clazz.ClassBuilder
 import net.theevilreaper.dartpoet.code.CodeBlock
 import net.theevilreaper.dartpoet.directive.Directive
-import net.theevilreaper.dartpoet.enum.EnumBuilder
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
-import net.theevilreaper.dartpoet.mixin.MixinBuilder
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.spec.TypeSpec
@@ -140,34 +138,46 @@ class DartFileBuilder(
         this.typeDefs += typeDef
     }
 
-    fun type(dartFileSpec: TypeSpec) = apply {
-        this.specTypes += dartFileSpec
+    /**
+     * Add a top level [TypeSpec] (e.g. [net.theevilreaper.dartpoet.clazz.ClassSpec], [net.theevilreaper.dartpoet.enum.EnumSpec], [net.theevilreaper.dartpoet.mixin.MixinSpec]) to the file.
+     * @param typeSpec the type specification to add
+     * @return the current instance of [DartFileBuilder]
+     */
+    fun type(typeSpec: TypeSpec) = apply {
+        this.specTypes += typeSpec
     }
 
+    /**
+     * Add a top level [TypeSpec] to the file over a lambda reference.
+     * @param typeSpec lambda returning the type specification to add
+     * @return the current instance of [DartFileBuilder]
+     */
+    fun type(typeSpec: () -> TypeSpec) = this.type(typeSpec())
+
+    /**
+     * Add an array of top level [TypeSpec]s to the file.
+     * @param typeSpecs the type specifications to add
+     * @return the current instance of [DartFileBuilder]
+     */
     fun type(vararg typeSpecs: TypeSpec) = apply {
         this.specTypes += typeSpecs
     }
 
+    /**
+     * Add an array of top level [TypeSpec]s to the file.
+     * @param typeSpecs the type specifications to add
+     * @return the current instance of [DartFileBuilder]
+     */
+    fun types(vararg typeSpecs: TypeSpec) = apply {
+        this.specTypes += typeSpecs
+    }
+
+    @Deprecated(
+        message = "Pass the built ClassSpec instead",
+        replaceWith = ReplaceWith("type(dartFileSpec.build())")
+    )
     fun type(dartFileSpec: ClassBuilder) = apply {
         this.specTypes += dartFileSpec.build()
-    }
-
-    /**
-     * Add an enum specification to the file builder using an [EnumBuilder].
-     * @param enumBuilder the builder whose built [EnumSpec] should be added
-     * @return the current instance of [DartFileBuilder]
-     */
-    fun type(enumBuilder: EnumBuilder) = apply {
-        this.specTypes += enumBuilder.build()
-    }
-
-    /**
-     * Add a mixin specification to the file builder using a [MixinBuilder].
-     * @param mixinBuilder the builder whose built [MixinSpec] should be added
-     * @return the current instance of [DartFileBuilder]
-     */
-    fun type(mixinBuilder: MixinBuilder) = apply {
-        this.specTypes += mixinBuilder.build()
     }
 
     fun annotations(vararg annotations: AnnotationSpec) = apply {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/DartFileBuilder.kt
@@ -8,6 +8,7 @@ import net.theevilreaper.dartpoet.enum.EnumBuilder
 import net.theevilreaper.dartpoet.extension.ExtensionSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.mixin.MixinBuilder
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.spec.TypeSpec
@@ -158,6 +159,15 @@ class DartFileBuilder(
      */
     fun type(enumBuilder: EnumBuilder) = apply {
         this.specTypes += enumBuilder.build()
+    }
+
+    /**
+     * Add a mixin specification to the file builder using a [MixinBuilder].
+     * @param mixinBuilder the builder whose built [MixinSpec] should be added
+     * @return the current instance of [DartFileBuilder]
+     */
+    fun type(mixinBuilder: MixinBuilder) = apply {
+        this.specTypes += mixinBuilder.build()
     }
 
     fun annotations(vararg annotations: AnnotationSpec) = apply {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -212,7 +212,12 @@ class ClassSpec internal constructor(
         /**
          * Create a new [ClassBuilder] instance for a mixin dart class.
          * @return the created instance
+         * @deprecated Use [net.theevilreaper.dartpoet.mixin.MixinSpec.builder] instead.
          */
+        @Deprecated(
+            message = "Use MixinSpec.builder(name) instead",
+            replaceWith = ReplaceWith("MixinSpec.builder(name)", "net.theevilreaper.dartpoet.mixin.MixinSpec")
+        )
         @JvmStatic
         fun mixinClass(name: String) = ClassBuilder(name, ClassType.MIXIN)
 

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/WriterHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/WriterHelper.kt
@@ -33,5 +33,6 @@ internal object WriterHelper {
     internal val parameterWriter by lazy { ParameterWriter() }
     internal val propertyWriter by lazy { PropertyWriter() }
     internal val typeDefWriter by lazy { TypeDefWriter() }
+    internal val mixinWriter by lazy { MixinWriter() }
     internal val operatorWriter by lazy { OperatorWriter() }
 }

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/MixinWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/MixinWriter.kt
@@ -1,0 +1,135 @@
+package net.theevilreaper.dartpoet.code.writer
+
+import net.theevilreaper.dartpoet.DartModifier.BASE
+import net.theevilreaper.dartpoet.DartModifier.PRIVATE
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.Writeable
+import net.theevilreaper.dartpoet.code.emitAnnotations
+import net.theevilreaper.dartpoet.code.emitConstants
+import net.theevilreaper.dartpoet.code.emitFunctions
+import net.theevilreaper.dartpoet.code.emitOperators
+import net.theevilreaper.dartpoet.code.emitProperties
+import net.theevilreaper.dartpoet.code.emitTypeDefs
+import net.theevilreaper.dartpoet.mixin.MixinSpec
+import net.theevilreaper.dartpoet.type.TypeVariableName
+import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
+import net.theevilreaper.dartpoet.util.CURLY_CLOSE
+import net.theevilreaper.dartpoet.util.CURLY_OPEN
+import net.theevilreaper.dartpoet.util.GREATER_THAN_SIGN
+import net.theevilreaper.dartpoet.util.LESS_THAN_SIGN
+import net.theevilreaper.dartpoet.util.NEW_LINE
+import net.theevilreaper.dartpoet.util.StringHelper
+
+/**
+ * The [MixinWriter] contains the logic to write a [MixinSpec] to a [CodeWriter].
+ *
+ * @author theEvilReaper
+ * @since 2.4.0
+ */
+internal class MixinWriter : Writeable<MixinSpec> {
+
+    override fun write(spec: MixinSpec, writer: CodeWriter) {
+        spec.annotations.emitAnnotations(writer, inLineAnnotations = false)
+        writeMixinHeader(spec, writer)
+        writeGenericArguments(spec, writer)
+        writeInheritance(spec, writer)
+
+        if (spec.hasNoContent) {
+            writeEmptyBody(spec, writer)
+            return
+        }
+
+        writeMixinBody(spec, writer)
+    }
+
+    private fun writeMixinHeader(spec: MixinSpec, writer: CodeWriter) {
+        val prefix = if (spec.isBase) "base mixin" else "mixin"
+        writer.emitCode("%L", prefix)
+        writer.emitSpace()
+        writer.emit(StringHelper.ensureVariableNameWithPrivateModifier(spec.name, spec.modifiers.contains(PRIVATE)))
+    }
+
+    private fun writeGenericArguments(spec: MixinSpec, writer: CodeWriter) {
+        when (spec.genericCasts.isEmpty()) {
+            true -> writer.emitSpace()
+            false -> {
+                val joinedGenerics = StringHelper.concatData(
+                    spec.genericCasts,
+                    prefix = LESS_THAN_SIGN,
+                    separator = COMMA_SEPARATOR,
+                    postfix = GREATER_THAN_SIGN
+                ) { TypeVariableName.renderDeclaration(it) }
+                writer.emitCode("%L", joinedGenerics)
+                writer.emitSpace()
+            }
+        }
+    }
+
+    private fun writeInheritance(spec: MixinSpec, writer: CodeWriter) {
+        if (spec.onTypes.isNotEmpty()) {
+            writer.emitCode("%L", "on")
+            writer.emitSpace()
+            val joinedOnTypes = StringHelper.concatData(spec.onTypes, separator = COMMA_SEPARATOR) { it.toString() }
+            writer.emitCode("%L", joinedOnTypes)
+            writer.emitSpace()
+        }
+
+        if (spec.interfaces.isNotEmpty()) {
+            writer.emitCode("%L", "implements")
+            writer.emitSpace()
+            val joinedInterfaces = StringHelper.concatData(spec.interfaces, separator = COMMA_SEPARATOR) { it.toString() }
+            writer.emitCode("%L", joinedInterfaces)
+            writer.emitSpace()
+        }
+    }
+
+    private fun writeEmptyBody(spec: MixinSpec, writer: CodeWriter) {
+        writer.emit("$CURLY_OPEN$CURLY_CLOSE")
+
+        if (spec.endsWithNewLine) {
+            writer.emit(NEW_LINE)
+        }
+    }
+
+    private fun writeMixinBody(spec: MixinSpec, writer: CodeWriter) {
+        writer.emit("{$NEW_LINE")
+        writer.emit(NEW_LINE)
+        writer.indent()
+
+        spec.constants.emitConstants(writer)
+
+        if (spec.constants.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+        }
+
+        spec.typeDefs.emitTypeDefs(writer)
+
+        if (spec.typeDefs.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+        }
+
+        spec.properties.emitProperties(writer)
+
+        if (spec.properties.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+        }
+
+        spec.functions.emitFunctions(writer)
+
+        if (spec.functions.isNotEmpty() && spec.operators.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+            writer.emit(NEW_LINE)
+        }
+        spec.operators.emitOperators(writer)
+
+        writer.unindent()
+        if (spec.functions.isNotEmpty() || spec.operators.isNotEmpty()) {
+            writer.emit(NEW_LINE)
+        }
+        writer.emit("}")
+
+        if (spec.endsWithNewLine) {
+            writer.emit(NEW_LINE)
+        }
+    }
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/mixin/MixinBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/mixin/MixinBuilder.kt
@@ -1,0 +1,214 @@
+package net.theevilreaper.dartpoet.mixin
+
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.meta.SpecData
+import net.theevilreaper.dartpoet.meta.SpecMethods
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
+import net.theevilreaper.dartpoet.type.asClassName
+import net.theevilreaper.dartpoet.type.asTypeName
+import java.lang.reflect.Type
+import kotlin.reflect.KClass
+
+/**
+ * A builder class for constructing instances of [MixinSpec].
+ * This builder provides methods to configure on types, interfaces, properties,
+ * functions, operators, constants, type aliases, generic type arguments, annotations, and modifiers.
+ *
+ * @param name The name of the mixin being built.
+ * @param modifiers Optional modifiers for the mixin.
+ *
+ * @author theEvilReaper
+ * @since 2.4.0
+ */
+class MixinBuilder internal constructor(
+    val name: String,
+    vararg modifiers: DartModifier
+) : SpecMethods<MixinBuilder> {
+    internal val specData: SpecData = SpecData(*modifiers)
+    internal val onTypes: MutableList<TypeName> = mutableListOf()
+    internal val interfaces: MutableList<TypeName> = mutableListOf()
+    internal val genericCasts: MutableList<TypeName> = mutableListOf()
+    internal val properties: MutableList<PropertySpec> = mutableListOf()
+    internal val functions: MutableList<FunctionSpec> = mutableListOf()
+    internal val operators: MutableList<DartOperatorSpec> = mutableListOf()
+    internal val constants: MutableSet<ConstantPropertySpec> = mutableSetOf()
+    internal val typeDefs: MutableList<AbstractTypeDef<*>> = mutableListOf()
+    internal var endWithNewLine: Boolean = false
+
+    fun on(vararg onTypes: TypeName) = apply {
+        this.onTypes += onTypes
+    }
+
+    fun on(vararg onTypes: Type) = apply {
+        this.onTypes += onTypes.map { it.asTypeName() }
+    }
+
+    fun on(vararg onTypes: KClass<*>) = apply {
+        this.onTypes += onTypes.map { it.asTypeName() }
+    }
+
+    @JvmName("implementsTypes")
+    fun implements(vararg interfaces: TypeName) = apply {
+        this.interfaces += interfaces
+    }
+
+    @JvmName("implementsTypes")
+    fun implements(vararg interfaces: Type) = apply {
+        this.interfaces += interfaces.map { it.asTypeName() }
+    }
+
+    @JvmName("implementsTypes")
+    fun implements(vararg interfaces: KClass<*>) = apply {
+        this.interfaces += interfaces.map { it.asTypeName() }
+    }
+
+    fun genericCast(typeName: TypeName) = apply {
+        this.genericCasts += typeName
+    }
+
+    fun genericCasts(vararg typeNames: TypeName) = apply {
+        this.genericCasts += typeNames
+    }
+
+    fun generic(type: ClassName) = apply {
+        this.genericCasts += type
+    }
+
+    fun generic(type: Type) = apply {
+        this.genericCasts += type.asTypeName()
+    }
+
+    fun generic(type: KClass<*>) = apply {
+        this.genericCasts += type.asClassName()
+    }
+
+    fun generic(type: Class<*>) = apply {
+        this.genericCasts += type.asClassName()
+    }
+
+    fun generic(name: String, bound: TypeName) = apply {
+        this.genericCasts += TypeVariableName(name, bound)
+    }
+
+    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
+
+    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
+
+    fun property(property: PropertySpec) = apply {
+        this.properties += property
+    }
+
+    fun property(property: () -> PropertySpec) = apply {
+        this.properties += property()
+    }
+
+    fun properties(vararg properties: PropertySpec) = apply {
+        this.properties += properties
+    }
+
+    fun properties(properties: Iterable<PropertySpec>) = apply {
+        this.properties += properties
+    }
+
+    fun function(function: FunctionSpec) = apply {
+        this.functions += function
+    }
+
+    fun function(function: () -> FunctionSpec) = apply {
+        this.functions += function()
+    }
+
+    fun functions(vararg functions: FunctionSpec) = apply {
+        this.functions += functions
+    }
+
+    fun functions(functions: Iterable<FunctionSpec>) = apply {
+        this.functions += functions
+    }
+
+    fun operator(operator: DartOperatorSpec) = apply {
+        this.operators += operator
+    }
+
+    fun operator(operator: () -> DartOperatorSpec) = apply {
+        this.operators += operator()
+    }
+
+    fun operators(vararg operators: DartOperatorSpec) = apply {
+        this.operators += operators
+    }
+
+    fun operators(operators: Iterable<DartOperatorSpec>) = apply {
+        this.operators += operators
+    }
+
+    fun constant(constant: ConstantPropertySpec) = apply {
+        this.constants += constant
+    }
+
+    fun constant(constant: () -> ConstantPropertySpec) = apply {
+        this.constants += constant()
+    }
+
+    fun constants(vararg constants: ConstantPropertySpec) = apply {
+        this.constants += constants
+    }
+
+    fun constants(constants: Iterable<ConstantPropertySpec>) = apply {
+        this.constants += constants
+    }
+
+    fun typeDef(typeDefSpec: AbstractTypeDef<*>) = apply {
+        this.typeDefs += typeDefSpec
+    }
+
+    fun typeDef(typeDefSpec: () -> AbstractTypeDef<*>) = apply {
+        this.typeDefs += typeDefSpec()
+    }
+
+    fun typeDefs(vararg typeDefSpecs: AbstractTypeDef<*>) = apply {
+        this.typeDefs += typeDefSpecs
+    }
+
+    fun typeDefs(typeDefSpecs: Iterable<AbstractTypeDef<*>>) = apply {
+        this.typeDefs += typeDefSpecs
+    }
+
+    override fun annotation(annotation: AnnotationSpec) = apply {
+        this.specData.annotation(annotation)
+    }
+
+    override fun annotation(annotation: () -> AnnotationSpec) = apply {
+        this.specData.annotation(annotation)
+    }
+
+    override fun annotations(vararg annotations: AnnotationSpec) = apply {
+        this.specData.annotations(*annotations)
+    }
+
+    override fun modifier(modifier: DartModifier) = apply {
+        this.specData.modifier(modifier)
+    }
+
+    override fun modifier(modifier: () -> DartModifier) = apply {
+        this.specData.modifier(modifier)
+    }
+
+    override fun modifiers(vararg modifiers: DartModifier) = apply {
+        this.specData.modifiers(*modifiers)
+    }
+
+    fun endWithNewLine(endWithNewLine: Boolean) = apply {
+        this.endWithNewLine = endWithNewLine
+    }
+
+    fun build(): MixinSpec = MixinSpec(this)
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpec.kt
@@ -1,0 +1,83 @@
+package net.theevilreaper.dartpoet.mixin
+
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.code.CodeWriter
+import net.theevilreaper.dartpoet.code.WriterHelper
+import net.theevilreaper.dartpoet.code.buildCodeString
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
+import net.theevilreaper.dartpoet.spec.TypeSpec
+import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.util.toImmutableList
+import net.theevilreaper.dartpoet.util.toImmutableSet
+
+/**
+ * A [MixinSpec] represents a mixin declaration in Dart.
+ * It implements [TypeSpec] so it can be used anywhere a top-level type declaration is expected.
+ *
+ * @author theEvilReaper
+ * @since 2.4.0
+ */
+class MixinSpec internal constructor(
+    builder: MixinBuilder,
+) : TypeSpec {
+    override val name: String = builder.name
+    val onTypes: List<TypeName> = builder.onTypes.toImmutableList()
+    val interfaces: List<TypeName> = builder.interfaces.toImmutableList()
+    val genericCasts: Set<TypeName> = builder.genericCasts.toImmutableSet()
+    val properties: Set<PropertySpec> = builder.properties.toImmutableSet()
+    val functions: Set<FunctionSpec> = builder.functions.toImmutableSet()
+    val operators: Set<DartOperatorSpec> = builder.operators.toImmutableSet()
+    val constants: Set<ConstantPropertySpec> = builder.constants.toImmutableSet()
+    val typeDefs: List<AbstractTypeDef<*>> = builder.typeDefs.toImmutableList()
+    val annotations: Set<AnnotationSpec> = builder.specData.annotations.toImmutableSet()
+    val modifiers: Set<DartModifier> = builder.specData.modifiers.toImmutableSet()
+    val endsWithNewLine: Boolean = builder.endWithNewLine
+    val isBase: Boolean = DartModifier.BASE in modifiers
+
+    internal val hasNoContent: Boolean
+        get() = properties.isEmpty() && functions.isEmpty() && operators.isEmpty() && constants.isEmpty() && typeDefs.isEmpty()
+
+    init {
+        check(name.isNotBlank() && !name.contains(" ")) { "The mixin name can not be empty or contain whitespaces" }
+        val invalidModifiers = modifiers.filter { it != DartModifier.PUBLIC && it != DartModifier.PRIVATE && it != DartModifier.BASE }
+        check(invalidModifiers.isEmpty()) { "A mixin can only have the 'base' modifier, but got: $invalidModifiers" }
+        check(onTypes.size == onTypes.distinct().size) { "Duplicate 'on' type(s) found: ${onTypes.groupingBy { it }.eachCount().filterValues { it > 1 }.keys}" }
+        check(interfaces.size == interfaces.distinct().size) { "Duplicate interface type(s) found: ${interfaces.groupingBy { it }.eachCount().filterValues { it > 1 }.keys}" }
+        check(operators.size == operators.distinctBy { it.operator }.size) { "Duplicate operator(s) found: ${operators.groupingBy { it.operator }.eachCount().filterValues { it > 1 }.map { it.key.symbol }}" }
+    }
+
+    override fun write(codeWriter: CodeWriter) {
+        WriterHelper.mixinWriter.write(this, codeWriter)
+    }
+
+    override fun toString(): String = buildCodeString { write(this) }
+
+    fun toBuilder(): MixinBuilder {
+        val builder = MixinBuilder(this.name)
+        builder.onTypes.addAll(this.onTypes)
+        builder.interfaces.addAll(this.interfaces)
+        builder.genericCasts.addAll(this.genericCasts)
+        builder.properties.addAll(this.properties)
+        builder.functions.addAll(this.functions)
+        builder.operators.addAll(this.operators)
+        builder.constants.addAll(this.constants)
+        builder.typeDefs.addAll(this.typeDefs)
+        builder.specData.annotations.addAll(this.annotations)
+        builder.specData.modifiers.addAll(this.modifiers)
+        builder.endWithNewLine = this.endsWithNewLine
+        return builder
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(name: String) = MixinBuilder(name)
+
+        @JvmStatic
+        fun builder(name: String, vararg modifiers: DartModifier) = MixinBuilder(name, *modifiers)
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/corpus/MixinCorpusTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/corpus/MixinCorpusTest.kt
@@ -1,0 +1,262 @@
+package net.theevilreaper.dartpoet.corpus
+
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.mixin.MixinSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.type.BOOLEAN
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.INTEGER
+import net.theevilreaper.dartpoet.type.ParameterizedTypeName.Companion.parameterizedBy
+import net.theevilreaper.dartpoet.type.STRING
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Corpus tests for MixinSpec verified against the Dart analyzer")
+class MixinCorpusTest {
+
+    @Test
+    fun `test standard mixin and base mixin applied to classes`() {
+        val loggerMixin = MixinSpec.builder("Logger")
+            .property(
+                PropertySpec.builder("logCount", INTEGER)
+                    .initWith("%L", "0")
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("log")
+                    .parameter(ParameterSpec.positional("message", STRING).build())
+                    .addCode("print('[\$logCount] \$message');")
+                    .build()
+            )
+            .build()
+
+        val baseWorkerMixin = MixinSpec.builder("BaseWorker")
+            .modifier(DartModifier.BASE)
+            .property(
+                PropertySpec.builder("workerId", STRING)
+                    .modifier(DartModifier.FINAL)
+                    .initWith("%S", "worker-1")
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("performTask")
+                    .addCode("print('Worker \$workerId performing task');")
+                    .build()
+            )
+            .build()
+
+        val appLogger = ClassSpec.builder("AppLogger")
+            .withMixins(ClassName("Logger"))
+            .function(
+                FunctionSpec.builder("run")
+                    .addCode("log('App started');")
+                    .build()
+            )
+            .build()
+
+        val taskRunner = ClassSpec.builder("TaskRunner")
+            .modifier(DartModifier.BASE)
+            .withMixins(ClassName("BaseWorker"))
+            .function(
+                FunctionSpec.builder("execute")
+                    .addCode("performTask();")
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("standard_and_base_mixin_corpus")
+            .type(loggerMixin)
+            .type(baseWorkerMixin)
+            .type(appLogger)
+            .type(taskRunner)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |mixin Logger {
+            |
+            |  int logCount = 0;
+            |
+            |  void log(String message) {
+            |    print('[${'$'}logCount] ${'$'}message');
+            |  }
+            |}
+            |base mixin BaseWorker {
+            |
+            |  final String workerId = "worker-1";
+            |
+            |  void performTask() {
+            |    print('Worker ${'$'}workerId performing task');
+            |  }
+            |}
+            |class AppLogger with Logger {
+            |
+            |  void run() {
+            |    log('App started');
+            |  }
+            |}
+            |base class TaskRunner with BaseWorker {
+            |
+            |  void execute() {
+            |    performTask();
+            |  }
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test mixin with on and implements clauses applied to subclass`() {
+        val animalClass = ClassSpec.abstractClass("Animal")
+            .function(
+                FunctionSpec.builder("makeSound")
+                    .build()
+            )
+            .build()
+
+        val identifiableInterface = ClassSpec.abstractClass("Identifiable")
+            .function(
+                FunctionSpec.builder("getId")
+                    .returns(STRING)
+                    .build()
+            )
+            .build()
+
+        val walkableMixin = MixinSpec.builder("Walkable")
+            .on(ClassName("Animal"))
+            .implements(ClassName("Identifiable"))
+            .function(
+                FunctionSpec.builder("walk")
+                    .addCode("makeSound();")
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("getId")
+                    .annotation(AnnotationSpec.builder("override").build())
+                    .returns(STRING)
+                    .addCode("return 'walkable-id';")
+                    .build()
+            )
+            .build()
+
+        val dogClass = ClassSpec.builder("Dog")
+            .superClass(ClassName("Animal"))
+            .withMixins(ClassName("Walkable"))
+            .function(
+                FunctionSpec.builder("makeSound")
+                    .annotation(AnnotationSpec.builder("override").build())
+                    .addCode("print('Woof');")
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("mixin_on_and_implements_corpus")
+            .type(animalClass)
+            .type(identifiableInterface)
+            .type(walkableMixin)
+            .type(dogClass)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |abstract class Animal {
+            |
+            |  void makeSound();
+            |}
+            |abstract class Identifiable {
+            |
+            |  String getId();
+            |}
+            |mixin Walkable on Animal implements Identifiable {
+            |
+            |  void walk() {
+            |    makeSound();
+            |  }
+            |
+            |  @override
+            |  String getId() {
+            |    return 'walkable-id';
+            |  }
+            |}
+            |class Dog extends Animal with Walkable {
+            |
+            |  @override
+            |  void makeSound() {
+            |    print('Woof');
+            |  }
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test generic mixin applied to generic class`() {
+        val cacheMixin = MixinSpec.builder("Cache")
+            .generic(ClassName("T"))
+            .property(
+                PropertySpec.builder("cachedItem", ClassName("T", isNullable = true))
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("store")
+                    .parameter(ParameterSpec.positional("item", ClassName("T")).build())
+                    .addCode("cachedItem = item;")
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("retrieve")
+                    .returns(ClassName("T", isNullable = true))
+                    .addCode("return cachedItem;")
+                    .build()
+            )
+            .build()
+
+        val repositoryClass = ClassSpec.builder("Repository")
+            .generic(ClassName("T"))
+            .withMixins(ClassName("Cache").parameterizedBy(ClassName("T")))
+            .function(
+                FunctionSpec.builder("hasItem")
+                    .returns(BOOLEAN)
+                    .addCode("return retrieve() != null;")
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("generic_mixin_corpus")
+            .type(cacheMixin)
+            .type(repositoryClass)
+            .build()
+
+        file.verifyDartOutput(
+            """
+            |mixin Cache<T> {
+            |
+            |  T? cachedItem;
+            |
+            |  void store(T item) {
+            |    cachedItem = item;
+            |  }
+            |
+            |  T? retrieve() {
+            |    return cachedItem;
+            |  }
+            |}
+            |class Repository<T> with Cache<T> {
+            |
+            |  bool hasItem() {
+            |    return retrieve() != null;
+            |  }
+            |}
+            |
+            """.trimMargin()
+        )
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
@@ -1,0 +1,347 @@
+package net.theevilreaper.dartpoet.mixin
+
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.annotation.AnnotationSpec
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.function.typedef.TypeDef
+import net.theevilreaper.dartpoet.operator.BinaryOperator
+import net.theevilreaper.dartpoet.operator.DartOperatorSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.verify.verifyDartOutput
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@DisplayName("Test MixinSpec generation and validation")
+class MixinSpecTest {
+
+    @Test
+    fun `test simple mixin generation`() {
+        val mixinSpec = MixinSpec.builder("Walkable").build()
+        mixinSpec.verifyDartOutput("mixin Walkable {}")
+    }
+
+    @Test
+    fun `test base mixin generation`() {
+        val mixinSpec = MixinSpec.builder("BaseWalkable")
+            .modifier(DartModifier.BASE)
+            .build()
+        mixinSpec.verifyDartOutput("base mixin BaseWalkable {}")
+    }
+
+    @Test
+    fun `test mixin with on clause`() {
+        val mixinSpec = MixinSpec.builder("Walkable")
+            .on(ClassName("Animal"), ClassName("Organism"))
+            .build()
+        assertEquals("mixin Walkable on Animal, Organism {}", mixinSpec.toString())
+    }
+
+    @Test
+    fun `test mixin with implements clause`() {
+        val mixinSpec = MixinSpec.builder("Walkable")
+            .implements(ClassName("HasLegs"))
+            .build()
+        assertEquals("mixin Walkable implements HasLegs {}", mixinSpec.toString())
+    }
+
+    @Test
+    fun `test mixin with both on and implements`() {
+        val mixinSpec = MixinSpec.builder("Walkable")
+            .on(ClassName("Animal"))
+            .implements(ClassName("HasLegs"))
+            .build()
+        assertEquals("mixin Walkable on Animal implements HasLegs {}", mixinSpec.toString())
+    }
+
+    @Test
+    fun `test mixin with properties, functions, and operators`() {
+        val mixinSpec = MixinSpec.builder("Calculator")
+            .property(
+                PropertySpec.builder("value", ClassName("int"))
+                    .initWith("%L", "0")
+                    .build()
+            )
+            .function(
+                FunctionSpec.builder("reset")
+                    .addCode("// reset")
+                    .build()
+            )
+            .operator(
+                DartOperatorSpec.builder(BinaryOperator.PLUS)
+                    .returnType(ClassName("int"))
+                    .parameter(ParameterSpec.positional("other", ClassName("int")).build())
+                    .addCode("return value + other;")
+                    .build()
+            )
+            .build()
+
+        mixinSpec.verifyDartOutput(
+            """
+            |mixin Calculator {
+            |
+            |  int value = 0;
+            |
+            |  void reset() {
+            |    // reset
+            |  }
+            |
+            |  int operator +(int other) {
+            |    return value + other;
+            |  }
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test generic mixin`() {
+        val mixinSpec = MixinSpec.builder("Cache")
+            .generic(ClassName("T"))
+            .build()
+        mixinSpec.verifyDartOutput("mixin Cache<T> {}")
+    }
+
+    @Test
+    fun `test generic mixin with bounded type`() {
+        val mixinSpec = MixinSpec.builder("Repository")
+            .generic("T", ClassName("Entity"))
+            .build()
+        assertEquals("mixin Repository<T extends Entity> {}", mixinSpec.toString())
+    }
+
+    @Test
+    fun `test mixin with constants`() {
+        val mixinSpec = MixinSpec.builder("ConstantsMixin")
+            .constant(
+                ConstantPropertySpec.classConst("version", String::class)
+                    .initWith("%C", "1.0.0")
+                    .build()
+            )
+            .build()
+
+        mixinSpec.verifyDartOutput(
+            """
+            |mixin ConstantsMixin {
+            |
+            |  static const String version = '1.0.0';
+            |
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test mixin with typedef`() {
+        val mixinSpec = MixinSpec.builder("TypedefMixin")
+            .typeDef(
+                TypeDef.alias("StringList")
+                    .returns(ClassName("List"))
+                    .build()
+            )
+            .build()
+
+        assertEquals(
+            """
+            |mixin TypedefMixin {
+            |
+            |  typedef StringList = List;
+            |
+            |}
+            """.trimMargin(),
+            mixinSpec.toString()
+        )
+    }
+
+    @Test
+    fun `test mixin ends with new line`() {
+        val mixinSpec = MixinSpec.builder("Trailing")
+            .endWithNewLine(true)
+            .build()
+        assertEquals("mixin Trailing {}\n", mixinSpec.toString())
+    }
+
+    @Test
+    fun `test private mixin`() {
+        val mixinSpec = MixinSpec.builder("PrivateMixin")
+            .modifier(DartModifier.PRIVATE)
+            .build()
+        mixinSpec.verifyDartOutput("mixin _PrivateMixin {}")
+    }
+
+    @Test
+    fun `test mixin inside DartFile`() {
+        val animal = ClassSpec.builder("Animal").build()
+        val walkable = MixinSpec.builder("Walkable")
+            .on(ClassName("Animal"))
+            .function(
+                FunctionSpec.builder("walk")
+                    .addCode("// walk")
+                    .build()
+            )
+            .build()
+        val dog = ClassSpec.builder("Dog")
+            .superClass(ClassName("Animal"))
+            .withMixins(ClassName("Walkable"))
+            .build()
+
+        val dartFile = DartFile.builder("animals")
+            .type(animal)
+            .type(walkable)
+            .type(dog)
+            .build()
+
+        dartFile.verifyDartOutput(
+            """
+            |class Animal {}
+            |mixin Walkable on Animal {
+            |
+            |  void walk() {
+            |    // walk
+            |  }
+            |}
+            |class Dog extends Animal with Walkable {}
+            |
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test mixin builder inside DartFile`() {
+        val mixinBuilder = MixinSpec.builder("Flyable")
+            .function(FunctionSpec.builder("fly").build())
+
+        val dartFile = DartFile.builder("flying")
+            .type(mixinBuilder)
+            .build()
+
+        dartFile.verifyDartOutput(
+            """
+            |mixin Flyable {
+            |
+            |  void fly();
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `test validation blank or whitespace name throws`() {
+        val exceptionEmpty = assertThrows<IllegalStateException> {
+            MixinSpec.builder("").build()
+        }
+        assertEquals("The mixin name can not be empty or contain whitespaces", exceptionEmpty.message)
+
+        val exceptionWhitespace = assertThrows<IllegalStateException> {
+            MixinSpec.builder("Invalid Name").build()
+        }
+        assertEquals("The mixin name can not be empty or contain whitespaces", exceptionWhitespace.message)
+    }
+
+    @Test
+    fun `test validation invalid modifier throws`() {
+        val exception = assertThrows<IllegalStateException> {
+            MixinSpec.builder("InvalidModifier")
+                .modifier(DartModifier.ABSTRACT)
+                .build()
+        }
+        assertTrue(exception.message!!.startsWith("A mixin can only have the 'base' modifier"))
+    }
+
+    @Test
+    fun `test validation duplicate on types throws`() {
+        val exception = assertThrows<IllegalStateException> {
+            MixinSpec.builder("DupOn")
+                .on(ClassName("Base"), ClassName("Base"))
+                .build()
+        }
+        assertTrue(exception.message!!.startsWith("Duplicate 'on' type(s) found"))
+    }
+
+    @Test
+    fun `test validation duplicate interfaces throws`() {
+        val exception = assertThrows<IllegalStateException> {
+            MixinSpec.builder("DupInterface")
+                .implements(ClassName("I1"), ClassName("I1"))
+                .build()
+        }
+        assertTrue(exception.message!!.startsWith("Duplicate interface type(s) found"))
+    }
+
+    @Test
+    fun `test validation duplicate operators throws`() {
+        val op1 = DartOperatorSpec.builder(BinaryOperator.PLUS)
+            .returnType(ClassName("int"))
+            .parameter(ParameterSpec.positional("other", ClassName("int")).build())
+            .addCode("return 1;")
+            .build()
+        val op2 = DartOperatorSpec.builder(BinaryOperator.PLUS)
+            .returnType(ClassName("int"))
+            .parameter(ParameterSpec.positional("other", ClassName("int")).build())
+            .addCode("return 2;")
+            .build()
+
+        val exception = assertThrows<IllegalStateException> {
+            MixinSpec.builder("DupOperator")
+                .operator(op1)
+                .operator(op2)
+                .build()
+        }
+        assertTrue(exception.message!!.startsWith("Duplicate operator(s) found"))
+    }
+
+    @Test
+    fun `test toBuilder roundtrip`() {
+        val original = MixinSpec.builder("Original")
+            .on(ClassName("Animal"))
+            .implements(ClassName("HasLegs"))
+            .generic(ClassName("T"))
+            .property(PropertySpec.builder("speed", ClassName("int")).build())
+            .function(FunctionSpec.builder("move").build())
+            .operator(
+                DartOperatorSpec.builder(BinaryOperator.PLUS)
+                    .returnType(ClassName("int"))
+                    .parameter(ParameterSpec.positional("other", ClassName("int")).build())
+                    .addCode("return speed + other;")
+                    .build()
+            )
+            .constant(
+                ConstantPropertySpec.classConst("maxSpeed", Int::class)
+                    .initWith("%L", "100")
+                    .build()
+            )
+            .typeDef(
+                TypeDef.alias("SpeedList")
+                    .returns(ClassName("List"))
+                    .build()
+            )
+            .annotation(AnnotationSpec.builder("deprecated").build())
+            .modifier(DartModifier.BASE)
+            .endWithNewLine(true)
+            .build()
+
+        val modified = original.toBuilder()
+            .property(PropertySpec.builder("distance", ClassName("int")).build())
+            .build()
+
+        assertEquals(1, original.properties.size)
+        assertEquals(2, modified.properties.size)
+        assertEquals(1, modified.onTypes.size)
+        assertEquals(1, modified.interfaces.size)
+        assertEquals(1, modified.genericCasts.size)
+        assertEquals(1, modified.functions.size)
+        assertEquals(1, modified.operators.size)
+        assertEquals(1, modified.constants.size)
+        assertEquals(1, modified.typeDefs.size)
+        assertEquals(1, modified.annotations.size)
+        assertTrue(modified.isBase)
+        assertTrue(modified.endsWithNewLine)
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
@@ -219,7 +219,7 @@ class MixinSpecTest {
             .function(FunctionSpec.builder("fly").build())
 
         val dartFile = DartFile.builder("flying")
-            .type(mixinBuilder)
+            .type(mixinBuilder.build())
             .build()
 
         dartFile.verifyDartOutput(


### PR DESCRIPTION
## Proposed changes

This PR continues the modularization of type declarations by extracting mixins into a dedicated specification and builder. This prevents invalid configurations like constructors or superclass extensions directly at compile time, while cleanly supporting Dart 3 base mixins as well as superclass and interface constraints.

Existing mixin creation methods on ClassSpec remain functional and are marked as deprecated for backward compatibility. In addition, type registration on DartFile has been simplified to handle all top-level types uniformly through a shared interface.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)