### PR TITLE
refactor(writer): simplify type writers

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassSpec.kt
@@ -35,6 +35,7 @@ class ClassSpec internal constructor(
     internal val modifiers: Set<DartModifier> = builder.classMetaData.modifiers.toImmutableSet()
     internal val annotations: Set<AnnotationSpec> = builder.classMetaData.annotations.toImmutableSet()
     internal val endsWithNewLine: Boolean = builder.endWithNewLine
+    // TODO(v3.0): Remove ClassType, isEnum, isMixin, and legacy enum/mixin properties once deprecated APIs are removed
     internal val isEnum: Boolean = builder.classType == ClassType.ENUM
     internal val isAbstract: Boolean = builder.classType == ClassType.ABSTRACT
     internal val isMixin: Boolean = builder.classType == ClassType.MIXIN

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/CodeWriterExtension.kt
@@ -12,9 +12,15 @@ import net.theevilreaper.dartpoet.operator.DartOperatorSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.property.consts.ConstantPropertySpec
+import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.TypeVariableName
+import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
 import net.theevilreaper.dartpoet.util.EMPTY_STRING
+import net.theevilreaper.dartpoet.util.GREATER_THAN_SIGN
+import net.theevilreaper.dartpoet.util.LESS_THAN_SIGN
 import net.theevilreaper.dartpoet.util.NEW_LINE
 import net.theevilreaper.dartpoet.util.SPACE
+import net.theevilreaper.dartpoet.util.StringHelper
 
 internal val SPECIAL_CHARACTERS = " \n·".toCharArray()
 internal val UNSAFE_LINE_START = Regex("\\s*[-+].*")
@@ -199,3 +205,38 @@ internal fun Set<PropertySpec>.emitProperties(
     forceNewLines: Boolean = false,
     emitBlock: (PropertySpec) -> Unit = { it.write(codeWriter) },
 ) = emitBlockElements(codeWriter, forceNewLines, emitBlock = emitBlock)
+
+/**
+ * Emits the generic type arguments declaration (e.g. `<T, R extends Object>`) to a [CodeWriter]
+ * followed by a space, or a single space if [generics] is empty.
+ * @param generics the generic type names to emit
+ */
+internal fun CodeWriter.emitGenericTypeArguments(generics: Collection<TypeName>) {
+    if (generics.isEmpty()) {
+        emitSpace()
+    } else {
+        val joinedGenerics = StringHelper.concatData(
+            generics,
+            prefix = LESS_THAN_SIGN,
+            separator = COMMA_SEPARATOR,
+            postfix = GREATER_THAN_SIGN
+        ) { TypeVariableName.renderDeclaration(it) }
+        emitCode("%L", joinedGenerics)
+        emitSpace()
+    }
+}
+
+/**
+ * Emits a clause keyword followed by comma-separated type names and a trailing space if [types] is not empty
+ * (e.g. `implements A, B ` or `with C, D ` or `on E, F `).
+ * @param keyword the clause keyword ("implements", "with", "on")
+ * @param types the type names to emit
+ */
+internal fun CodeWriter.emitTypeClause(keyword: String, types: Collection<TypeName>) {
+    if (types.isEmpty()) return
+    emitCode("%L", keyword)
+    emitSpace()
+    val joinedTypes = StringHelper.concatData(types, separator = COMMA_SEPARATOR) { it.toString() }
+    emitCode("%L", joinedTypes)
+    emitSpace()
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -10,7 +10,6 @@ import net.theevilreaper.dartpoet.code.emitConstructors
 import net.theevilreaper.dartpoet.code.emitFunctions
 import net.theevilreaper.dartpoet.code.emitOperators
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
-import net.theevilreaper.dartpoet.type.TypeVariableName
 import net.theevilreaper.dartpoet.util.*
 import net.theevilreaper.dartpoet.util.CURLY_CLOSE
 import net.theevilreaper.dartpoet.util.CURLY_OPEN

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/ClassWriter.kt
@@ -139,19 +139,7 @@ internal class ClassWriter : Writeable<ClassSpec> {
      * @param writer the [CodeWriter] to write the generic arguments
      */
     private fun writeGenericArguments(spec: ClassSpec, writer: CodeWriter) {
-        when (spec.genericCasts.isEmpty()) {
-            true -> writer.emitSpace()
-            false -> {
-                val joinedGenerics = StringHelper.concatData(
-                    spec.genericCasts,
-                    prefix = LESS_THAN_SIGN,
-                    separator = COMMA_SEPARATOR,
-                    postfix = GREATER_THAN_SIGN
-                ) { TypeVariableName.renderDeclaration(it) }
-                writer.emitCode("%L", joinedGenerics)
-                writer.emitSpace()
-            }
-        }
+        writer.emitGenericTypeArguments(spec.genericCasts)
     }
 
     /**
@@ -193,10 +181,8 @@ internal class ClassWriter : Writeable<ClassSpec> {
         writer.emit(StringHelper.ensureVariableNameWithPrivateModifier(spec.name, spec.modifiers.contains(PRIVATE)))
     }
 
-
-
     /**
-     * Writes the `extends`, `with` and `implements` clauses of a class header in that order.
+     * Writes the `extends`, `with`, `on` and `implements` clauses of a class header in that order.
      * Skips any clause the [spec] doesn't declare.
      * @param spec the [ClassSpec] which contains the super class, mixins and interfaces
      * @param writer the [CodeWriter] to write the inheritance clauses to
@@ -208,30 +194,9 @@ internal class ClassWriter : Writeable<ClassSpec> {
             writer.emitCode("%T", spec.superClass)
             writer.emitSpace()
         }
-
-        if (spec.mixins.isNotEmpty()) {
-            writer.emitCode("%L", "with")
-            writer.emitSpace()
-            val joinedMixins = StringHelper.concatData(spec.mixins, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedMixins)
-            writer.emitSpace()
-        }
-
-        if (spec.onTypes.isNotEmpty()) {
-            writer.emitCode("%L", "on")
-            writer.emitSpace()
-            val joinedOnTypes = StringHelper.concatData(spec.onTypes, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedOnTypes)
-            writer.emitSpace()
-        }
-
-        if (spec.interfaces.isNotEmpty()) {
-            writer.emitCode("%L", "implements")
-            writer.emitSpace()
-            val joinedInterfaces = StringHelper.concatData(spec.interfaces, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedInterfaces)
-            writer.emitSpace()
-        }
+        writer.emitTypeClause("with", spec.mixins)
+        writer.emitTypeClause("on", spec.onTypes)
+        writer.emitTypeClause("implements", spec.interfaces)
     }
 
     /**

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/EnumWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/EnumWriter.kt
@@ -7,8 +7,10 @@ import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.code.emitConstants
 import net.theevilreaper.dartpoet.code.emitConstructors
 import net.theevilreaper.dartpoet.code.emitFunctions
+import net.theevilreaper.dartpoet.code.emitGenericTypeArguments
 import net.theevilreaper.dartpoet.code.emitOperators
 import net.theevilreaper.dartpoet.code.emitProperties
+import net.theevilreaper.dartpoet.code.emitTypeClause
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.enum.EnumSpec
 import net.theevilreaper.dartpoet.type.TypeVariableName
@@ -49,37 +51,12 @@ internal class EnumWriter : Writeable<EnumSpec> {
     }
 
     private fun writeGenericArguments(spec: EnumSpec, writer: CodeWriter) {
-        when (spec.genericCasts.isEmpty()) {
-            true -> writer.emitSpace()
-            false -> {
-                val joinedGenerics = StringHelper.concatData(
-                    spec.genericCasts,
-                    prefix = LESS_THAN_SIGN,
-                    separator = COMMA_SEPARATOR,
-                    postfix = GREATER_THAN_SIGN
-                ) { TypeVariableName.renderDeclaration(it) }
-                writer.emitCode("%L", joinedGenerics)
-                writer.emitSpace()
-            }
-        }
+        writer.emitGenericTypeArguments(spec.genericCasts)
     }
 
     private fun writeInheritance(spec: EnumSpec, writer: CodeWriter) {
-        if (spec.mixins.isNotEmpty()) {
-            writer.emitCode("%L", "with")
-            writer.emitSpace()
-            val joinedMixins = StringHelper.concatData(spec.mixins, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedMixins)
-            writer.emitSpace()
-        }
-
-        if (spec.interfaces.isNotEmpty()) {
-            writer.emitCode("%L", "implements")
-            writer.emitSpace()
-            val joinedInterfaces = StringHelper.concatData(spec.interfaces, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedInterfaces)
-            writer.emitSpace()
-        }
+        writer.emitTypeClause("with", spec.mixins)
+        writer.emitTypeClause("implements", spec.interfaces)
     }
 
     private fun writeEnumBody(spec: EnumSpec, writer: CodeWriter) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/EnumWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/EnumWriter.kt
@@ -13,10 +13,6 @@ import net.theevilreaper.dartpoet.code.emitProperties
 import net.theevilreaper.dartpoet.code.emitTypeClause
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.enum.EnumSpec
-import net.theevilreaper.dartpoet.type.TypeVariableName
-import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
-import net.theevilreaper.dartpoet.util.GREATER_THAN_SIGN
-import net.theevilreaper.dartpoet.util.LESS_THAN_SIGN
 import net.theevilreaper.dartpoet.util.NEW_LINE
 import net.theevilreaper.dartpoet.util.SEMICOLON
 import net.theevilreaper.dartpoet.util.StringHelper

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/MixinWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/MixinWriter.kt
@@ -7,8 +7,10 @@ import net.theevilreaper.dartpoet.code.Writeable
 import net.theevilreaper.dartpoet.code.emitAnnotations
 import net.theevilreaper.dartpoet.code.emitConstants
 import net.theevilreaper.dartpoet.code.emitFunctions
+import net.theevilreaper.dartpoet.code.emitGenericTypeArguments
 import net.theevilreaper.dartpoet.code.emitOperators
 import net.theevilreaper.dartpoet.code.emitProperties
+import net.theevilreaper.dartpoet.code.emitTypeClause
 import net.theevilreaper.dartpoet.code.emitTypeDefs
 import net.theevilreaper.dartpoet.mixin.MixinSpec
 import net.theevilreaper.dartpoet.type.TypeVariableName
@@ -50,37 +52,12 @@ internal class MixinWriter : Writeable<MixinSpec> {
     }
 
     private fun writeGenericArguments(spec: MixinSpec, writer: CodeWriter) {
-        when (spec.genericCasts.isEmpty()) {
-            true -> writer.emitSpace()
-            false -> {
-                val joinedGenerics = StringHelper.concatData(
-                    spec.genericCasts,
-                    prefix = LESS_THAN_SIGN,
-                    separator = COMMA_SEPARATOR,
-                    postfix = GREATER_THAN_SIGN
-                ) { TypeVariableName.renderDeclaration(it) }
-                writer.emitCode("%L", joinedGenerics)
-                writer.emitSpace()
-            }
-        }
+        writer.emitGenericTypeArguments(spec.genericCasts)
     }
 
     private fun writeInheritance(spec: MixinSpec, writer: CodeWriter) {
-        if (spec.onTypes.isNotEmpty()) {
-            writer.emitCode("%L", "on")
-            writer.emitSpace()
-            val joinedOnTypes = StringHelper.concatData(spec.onTypes, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedOnTypes)
-            writer.emitSpace()
-        }
-
-        if (spec.interfaces.isNotEmpty()) {
-            writer.emitCode("%L", "implements")
-            writer.emitSpace()
-            val joinedInterfaces = StringHelper.concatData(spec.interfaces, separator = COMMA_SEPARATOR) { it.toString() }
-            writer.emitCode("%L", joinedInterfaces)
-            writer.emitSpace()
-        }
+        writer.emitTypeClause("on", spec.onTypes)
+        writer.emitTypeClause("implements", spec.interfaces)
     }
 
     private fun writeEmptyBody(spec: MixinSpec, writer: CodeWriter) {

--- a/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/MixinWriter.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/code/writer/MixinWriter.kt
@@ -1,6 +1,5 @@
 package net.theevilreaper.dartpoet.code.writer
 
-import net.theevilreaper.dartpoet.DartModifier.BASE
 import net.theevilreaper.dartpoet.DartModifier.PRIVATE
 import net.theevilreaper.dartpoet.code.CodeWriter
 import net.theevilreaper.dartpoet.code.Writeable
@@ -13,12 +12,8 @@ import net.theevilreaper.dartpoet.code.emitProperties
 import net.theevilreaper.dartpoet.code.emitTypeClause
 import net.theevilreaper.dartpoet.code.emitTypeDefs
 import net.theevilreaper.dartpoet.mixin.MixinSpec
-import net.theevilreaper.dartpoet.type.TypeVariableName
-import net.theevilreaper.dartpoet.util.COMMA_SEPARATOR
 import net.theevilreaper.dartpoet.util.CURLY_CLOSE
 import net.theevilreaper.dartpoet.util.CURLY_OPEN
-import net.theevilreaper.dartpoet.util.GREATER_THAN_SIGN
-import net.theevilreaper.dartpoet.util.LESS_THAN_SIGN
 import net.theevilreaper.dartpoet.util.NEW_LINE
 import net.theevilreaper.dartpoet.util.StringHelper
 


### PR DESCRIPTION
## Proposed changes

This PR simplifies the type writers by centralizing repetitive formatting logic for generic type arguments and inheritance clauses into shared CodeWriter extensions.

`ClassWriter`, `EnumWriter` and `MixinWriter` now reuse the same helpers for generic parameters as well as `implements`, `with` and `on` clauses, removing duplicated boilerplate across all type writers. Additionally, a roadmap note was added to ClassSpec outlining the planned cleanup of legacy flags for the upcoming major release.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)