### PR TITLE
feat(meta): add GenericMethods interface

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/clazz/ClassBuilder.kt
@@ -5,6 +5,7 @@ import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.constructor.ConstructorBase
 import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.meta.GenericMethods
 import net.theevilreaper.dartpoet.meta.SpecData
 import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.operator.DartOperatorSpec
@@ -30,7 +31,7 @@ class ClassBuilder internal constructor(
     internal val name: String?,
     internal val classType: ClassType,
     vararg modifiers: DartModifier
-) : SpecMethods<ClassBuilder> {
+) : SpecMethods<ClassBuilder>, GenericMethods<ClassBuilder> {
     internal val classMetaData: SpecData = SpecData(*modifiers)
     internal val constructorStack: MutableList<ConstructorBase> = mutableListOf()
     internal val propertyStack: MutableList<PropertySpec> = mutableListOf()
@@ -364,11 +365,38 @@ class ClassBuilder internal constructor(
     }
 
     /**
+     * Adds a generic type parameter as a [TypeName].
+     * @param typeName the type name to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    override fun genericCast(typeName: TypeName) = apply {
+        this.genericCasts += typeName
+    }
+
+    /**
+     * Adds multiple generic type parameters as [TypeName] instances.
+     * @param typeNames the type names to add
+     * @return the given instance of an [ClassBuilder]
+     */
+    override fun genericCasts(vararg typeNames: TypeName) = apply {
+        this.genericCasts += typeNames
+    }
+
+    /**
+     * Add an unconstrained generic type parameter with the given [name].
+     * @param name the name of the generic type variable (e.g. "T")
+     * @return the given instance of an [ClassBuilder]
+     */
+    override fun generic(name: String) = apply {
+        this.genericCasts += TypeVariableName(name)
+    }
+
+    /**
      * Add a generic type to the class builder.
      * @param type the [ClassName] to add
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(type: ClassName) = apply {
+    override fun generic(type: ClassName) = apply {
         this.genericCasts += type
     }
 
@@ -377,7 +405,7 @@ class ClassBuilder internal constructor(
      * @param type the [Type] to add
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(type: Type) = apply {
+    override fun generic(type: Type) = apply {
         generic(TypeName.get(type) as ClassName)
     }
 
@@ -386,7 +414,7 @@ class ClassBuilder internal constructor(
      * @param type the [KClass] to add
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(type: KClass<*>) = apply {
+    override fun generic(type: KClass<*>) = apply {
         generic(type.asClassName())
     }
 
@@ -395,7 +423,7 @@ class ClassBuilder internal constructor(
      * @param type the [Class] to add
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(type: Class<*>) = apply {
+    override fun generic(type: Class<*>) = apply {
         generic(type.asClassName())
     }
 
@@ -405,7 +433,7 @@ class ClassBuilder internal constructor(
      * @param bound the bound of the type parameter, represented as a [TypeName]
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(name: String, bound: TypeName) = apply {
+    override fun generic(name: String, bound: TypeName) = apply {
         this.genericCasts += TypeVariableName(name, bound)
     }
 
@@ -415,7 +443,7 @@ class ClassBuilder internal constructor(
      * @param bound the bound of the type parameter, represented as a [ClassName]
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
+    override fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
 
     /**
      * Add a bounded generic type parameter to the class builder, e.g. `T extends Bar`.
@@ -423,7 +451,15 @@ class ClassBuilder internal constructor(
      * @param bound the bound of the type parameter, represented as a [KClass]
      * @return the given instance of an [ClassBuilder]
      */
-    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
+    override fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
+
+    /**
+     * Add a bounded generic type parameter to the class builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a Java [Class]
+     * @return the given instance of an [ClassBuilder]
+     */
+    override fun generic(name: String, bound: Class<*>) = generic(name, bound.asClassName())
 
     /**
      * Creates a new instance from the [ClassSpec].

--- a/src/main/kotlin/net/theevilreaper/dartpoet/enum/EnumBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/enum/EnumBuilder.kt
@@ -4,6 +4,7 @@ import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.constructor.ConstructorBase
 import net.theevilreaper.dartpoet.function.FunctionSpec
+import net.theevilreaper.dartpoet.meta.GenericMethods
 import net.theevilreaper.dartpoet.meta.SpecData
 import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.operator.DartOperatorSpec
@@ -31,7 +32,7 @@ import kotlin.reflect.KClass
 class EnumBuilder internal constructor(
     val name: String,
     vararg modifiers: DartModifier
-) : SpecMethods<EnumBuilder> {
+) : SpecMethods<EnumBuilder>, GenericMethods<EnumBuilder> {
     internal val classMetaData: SpecData = SpecData(*modifiers)
     internal val entries: MutableList<EnumEntrySpec> = mutableListOf()
     internal val properties: MutableList<PropertySpec> = mutableListOf()
@@ -87,33 +88,37 @@ class EnumBuilder internal constructor(
         this.interfaces += interfaces.map { it.asTypeName() }
     }
 
-    fun genericCast(typeName: TypeName) = apply {
+    override fun genericCast(typeName: TypeName) = apply {
         this.genericCasts += typeName
     }
 
-    fun genericCasts(vararg typeNames: TypeName) = apply {
+    override fun genericCasts(vararg typeNames: TypeName) = apply {
         this.genericCasts += typeNames
     }
 
-    fun generic(type: ClassName) = apply {
+    override fun generic(name: String) = apply {
+        this.genericCasts += TypeVariableName(name)
+    }
+
+    override fun generic(type: ClassName) = apply {
         this.genericCasts += type
     }
 
-    fun generic(type: Type) = apply {
+    override fun generic(type: Type) = apply {
         this.genericCasts += type.asTypeName()
     }
 
-    fun generic(type: KClass<*>) = apply {
+    override fun generic(type: KClass<*>) = apply {
         this.genericCasts += type.asClassName()
     }
 
-    fun generic(name: String, bound: TypeName) = apply {
-        this.genericCasts += TypeVariableName(name, bound)
+    override fun generic(type: Class<*>) = apply {
+        this.genericCasts += type.asClassName()
     }
 
-    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
-
-    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
+    override fun generic(name: String, bound: TypeName) = apply {
+        this.genericCasts += TypeVariableName(name, bound)
+    }
 
     fun property(property: PropertySpec) = apply {
         this.properties += property

--- a/src/main/kotlin/net/theevilreaper/dartpoet/meta/GenericMethods.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/meta/GenericMethods.kt
@@ -1,0 +1,113 @@
+package net.theevilreaper.dartpoet.meta
+
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.TypeName
+import net.theevilreaper.dartpoet.type.asClassName
+import net.theevilreaper.dartpoet.type.asTypeName
+import java.lang.reflect.Type
+import kotlin.reflect.KClass
+
+/**
+ * Defines builder methods for declarations that support generic type parameters.
+ *
+ * Implemented by builders such as `ClassBuilder`, `EnumBuilder`, and `MixinBuilder`
+ * to offer a consistent, fluent API for configuring type parameters with or without bounds.
+ *
+ * @param T the concrete builder type for fluent method chaining
+ * @author theEvilReaper
+ * @since 2.4.0
+ */
+internal interface GenericMethods<T> {
+
+    /**
+     * Adds a generic type parameter as a [TypeName].
+     *
+     * @param typeName the type name to add
+     * @return this builder instance
+     */
+    fun genericCast(typeName: TypeName): T
+
+    /**
+     * Adds multiple generic type parameters as [TypeName] instances.
+     *
+     * @param typeNames the type names to add
+     * @return this builder instance
+     */
+    fun genericCasts(vararg typeNames: TypeName): T
+
+    /**
+     * Adds an unconstrained generic type parameter, such as `<T>`.
+     *
+     * @param name the type parameter name (e.g. "T", "Item", or "Result")
+     * @return this builder instance
+     */
+    fun generic(name: String): T
+
+    /**
+     * Adds a generic type parameter from a [ClassName].
+     *
+     * @param type the class name representing the type parameter
+     * @return this builder instance
+     */
+    fun generic(type: ClassName): T
+
+    /**
+     * Adds a generic type parameter from a Java reflection [Type].
+     *
+     * @param type the reflection type to convert and add
+     * @return this builder instance
+     */
+    fun generic(type: Type): T
+
+    /**
+     * Adds a generic type parameter from a Kotlin [KClass].
+     *
+     * @param type the Kotlin class to convert and add
+     * @return this builder instance
+     */
+    fun generic(type: KClass<*>): T
+
+    /**
+     * Adds a generic type parameter from a Java [Class].
+     *
+     * @param type the Java class to convert and add
+     * @return this builder instance
+     */
+    fun generic(type: Class<*>): T
+
+    /**
+     * Adds a bounded generic type parameter, such as `<T extends Comparable>`.
+     *
+     * @param name the name of the type parameter
+     * @param bound the upper bound that the type parameter must satisfy
+     * @return this builder instance
+     */
+    fun generic(name: String, bound: TypeName): T
+
+    /**
+     * Adds a bounded generic type parameter using a [ClassName] bound.
+     *
+     * @param name the name of the type parameter
+     * @param bound the upper bound as a [ClassName]
+     * @return this builder instance
+     */
+    fun generic(name: String, bound: ClassName): T = generic(name, bound as TypeName)
+
+    /**
+     * Adds a bounded generic type parameter using a Kotlin [KClass] bound.
+     *
+     * @param name the name of the type parameter
+     * @param bound the upper bound as a Kotlin class
+     * @return this builder instance
+     */
+    fun generic(name: String, bound: KClass<*>): T = generic(name, bound.asTypeName())
+
+    /**
+     * Adds a bounded generic type parameter using a Java [Class] bound.
+     *
+     * @param name the name of the type parameter
+     * @param bound the upper bound as a Java class
+     * @return this builder instance
+     */
+    fun generic(name: String, bound: Class<*>): T = generic(name, bound.asClassName())
+}

--- a/src/main/kotlin/net/theevilreaper/dartpoet/meta/GenericMethods.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/meta/GenericMethods.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KClass
  * @author theEvilReaper
  * @since 2.4.0
  */
-internal interface GenericMethods<T> {
+interface GenericMethods<T> {
 
     /**
      * Adds a generic type parameter as a [TypeName].

--- a/src/main/kotlin/net/theevilreaper/dartpoet/mixin/MixinBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/mixin/MixinBuilder.kt
@@ -4,6 +4,7 @@ import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.function.FunctionSpec
 import net.theevilreaper.dartpoet.function.typedef.AbstractTypeDef
+import net.theevilreaper.dartpoet.meta.GenericMethods
 import net.theevilreaper.dartpoet.meta.SpecData
 import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.operator.DartOperatorSpec
@@ -31,7 +32,7 @@ import kotlin.reflect.KClass
 class MixinBuilder internal constructor(
     val name: String,
     vararg modifiers: DartModifier
-) : SpecMethods<MixinBuilder> {
+) : SpecMethods<MixinBuilder>, GenericMethods<MixinBuilder> {
     internal val specData: SpecData = SpecData(*modifiers)
     internal val onTypes: MutableList<TypeName> = mutableListOf()
     internal val interfaces: MutableList<TypeName> = mutableListOf()
@@ -70,37 +71,37 @@ class MixinBuilder internal constructor(
         this.interfaces += interfaces.map { it.asTypeName() }
     }
 
-    fun genericCast(typeName: TypeName) = apply {
+    override fun genericCast(typeName: TypeName) = apply {
         this.genericCasts += typeName
     }
 
-    fun genericCasts(vararg typeNames: TypeName) = apply {
+    override fun genericCasts(vararg typeNames: TypeName) = apply {
         this.genericCasts += typeNames
     }
 
-    fun generic(type: ClassName) = apply {
+    override fun generic(name: String) = apply {
+        this.genericCasts += TypeVariableName(name)
+    }
+
+    override fun generic(type: ClassName) = apply {
         this.genericCasts += type
     }
 
-    fun generic(type: Type) = apply {
+    override fun generic(type: Type) = apply {
         this.genericCasts += type.asTypeName()
     }
 
-    fun generic(type: KClass<*>) = apply {
+    override fun generic(type: KClass<*>) = apply {
         this.genericCasts += type.asClassName()
     }
 
-    fun generic(type: Class<*>) = apply {
+    override fun generic(type: Class<*>) = apply {
         this.genericCasts += type.asClassName()
     }
 
-    fun generic(name: String, bound: TypeName) = apply {
+    override fun generic(name: String, bound: TypeName) = apply {
         this.genericCasts += TypeVariableName(name, bound)
     }
-
-    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
-
-    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
 
     fun property(property: PropertySpec) = apply {
         this.properties += property

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
@@ -24,17 +24,11 @@ class GenericClassTest {
 
     companion object {
         @JvmStatic
-        private fun genericOverloadCases(): Stream<Arguments> {
-            val reflectType: Type = String::class.java
-            return Stream.of(
-                Arguments.of(ClassSpec.builder("TestClass").generic("T").build(), "class TestClass<T> {}"),
-                Arguments.of(ClassSpec.builder("TestClass").generic(String::class).build(), "class TestClass<String> {}"),
-                Arguments.of(ClassSpec.builder("TestClass").generic(reflectType).build(), "class TestClass<String> {}"),
-            )
-        }
-
-        @JvmStatic
-        private fun boundedGenericCases(): Stream<Arguments> = Stream.of(
+        private fun genericClassCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                ClassSpec.builder("TestClass").generic("T").build(),
+                "class TestClass<T> {}"
+            ),
             Arguments.of(
                 ClassSpec.builder("Box").generic("T", ClassName("Comparable")).build(),
                 "class Box<T extends Comparable> {}"
@@ -103,15 +97,8 @@ class GenericClassTest {
 
     @DartAnalyzeCase
     @ParameterizedTest
-    @MethodSource("genericOverloadCases")
-    fun `test generic class with KClass and Type overloads`(classSpec: ClassSpec, expected: String) {
-        assertThat(classSpec.toString()).isEqualTo(expected)
-    }
-
-    @DartAnalyzeCase
-    @ParameterizedTest
-    @MethodSource("boundedGenericCases")
-    fun `test generic class with bounded type parameter`(classSpec: ClassSpec, expected: String) {
+    @MethodSource("genericClassCases")
+    fun `test generic class declarations`(classSpec: ClassSpec, expected: String) {
         assertThat(classSpec.toString()).isEqualTo(expected)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/classTypes/GenericClassTest.kt
@@ -27,6 +27,7 @@ class GenericClassTest {
         private fun genericOverloadCases(): Stream<Arguments> {
             val reflectType: Type = String::class.java
             return Stream.of(
+                Arguments.of(ClassSpec.builder("TestClass").generic("T").build(), "class TestClass<T> {}"),
                 Arguments.of(ClassSpec.builder("TestClass").generic(String::class).build(), "class TestClass<String> {}"),
                 Arguments.of(ClassSpec.builder("TestClass").generic(reflectType).build(), "class TestClass<String> {}"),
             )

--- a/src/test/kotlin/net/theevilreaper/dartpoet/enum/EnumSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/enum/EnumSpecTest.kt
@@ -108,35 +108,18 @@ class EnumSpecTest {
     @Test
     fun `test generic enum`() {
         val enumSpec = EnumSpec.builder("Result")
-            .genericCast(ClassName("T"))
+            .generic("T")
+            .generic("E", Comparable::class)
             .entry(EnumEntrySpec.builder("success").build())
             .entry(EnumEntrySpec.builder("failure").build())
             .build()
 
         enumSpec.verifyDartOutput(
             """
-            |enum Result<T> {
+            |enum Result<T, E extends Comparable> {
             |
             |  success,
             |  failure
-            |}
-            """.trimMargin()
-        )
-    }
-
-    @Test
-    fun `test generic enum with string and bound overloads`() {
-        val enumSpec = EnumSpec.builder("Result")
-            .generic("T")
-            .generic("E", Comparable::class)
-            .entry(EnumEntrySpec.builder("success").build())
-            .build()
-
-        enumSpec.verifyDartOutput(
-            """
-            |enum Result<T, E extends Comparable> {
-            |
-            |  success
             |}
             """.trimMargin()
         )
@@ -216,16 +199,13 @@ class EnumSpecTest {
     }
 
     @Test
-    fun `test validation empty entries throws`() {
-        val exception = assertThrows<IllegalStateException> {
+    fun `test validation throws on invalid entries`() {
+        val emptyEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("EmptyEnum").build()
         }
-        assertEquals("An enum requires at least one enum entry", exception.message)
-    }
+        assertEquals("An enum requires at least one enum entry", emptyEx.message)
 
-    @Test
-    fun `test validation entry parameter count mismatch throws`() {
-        val exception = assertThrows<IllegalStateException> {
+        val mismatchEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("MismatchEnum")
                 .property(PropertySpec.builder("name", String::class).build())
                 .entry(
@@ -236,86 +216,73 @@ class EnumSpecTest {
                 )
                 .build()
         }
-        assertEquals("The entries from the enum property must have the same size", exception.message)
+        assertEquals("The entries from the enum property must have the same size", mismatchEx.message)
     }
 
     @Test
-    fun `test validation duplicate mixin throws`() {
-        val exception = assertThrows<IllegalStateException> {
+    fun `test validation throws on duplicate elements`() {
+        val dupMixinEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("DupMixin")
                 .withMixins(ClassName("M1"), ClassName("M1"))
                 .entry(EnumEntrySpec.builder("entry").build())
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Duplicate mixin type(s) found"))
-    }
+        assertTrue(dupMixinEx.message!!.startsWith("Duplicate mixin type(s) found"))
 
-    @Test
-    fun `test validation duplicate interface throws`() {
-        val exception = assertThrows<IllegalStateException> {
+        val dupInterfaceEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("DupInterface")
                 .implements(ClassName("I1"), ClassName("I1"))
                 .entry(EnumEntrySpec.builder("entry").build())
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Duplicate interface type(s) found"))
-    }
+        assertTrue(dupInterfaceEx.message!!.startsWith("Duplicate interface type(s) found"))
 
-    @Test
-    fun `test validation duplicate operator throws`() {
+        val dupEntryEx = assertThrows<IllegalStateException> {
+            EnumSpec.builder("DupEntries")
+                .entry(EnumEntrySpec.builder("same").build())
+                .entry(EnumEntrySpec.builder("same").build())
+                .build()
+        }
+        assertTrue(dupEntryEx.message!!.startsWith("Duplicate enum entry name(s) found"))
+
         val op1 = DartOperatorSpec.builder(BinaryOperator.PLUS)
             .returnType(ClassName("int"))
             .parameter(ParameterSpec.positional("other", ClassName("int")).build())
-            .addCode("return %L;", "1")
+            .addCode("return 1;")
             .build()
         val op2 = DartOperatorSpec.builder(BinaryOperator.PLUS)
             .returnType(ClassName("int"))
             .parameter(ParameterSpec.positional("other", ClassName("int")).build())
-            .addCode("return %L;", "2")
+            .addCode("return 2;")
             .build()
-
-        val exception = assertThrows<IllegalStateException> {
+        val dupOperatorEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("DupOperator")
                 .entry(EnumEntrySpec.builder("entry").build())
                 .operator(op1)
                 .operator(op2)
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Duplicate operator(s) found"))
+        assertTrue(dupOperatorEx.message!!.startsWith("Duplicate operator(s) found"))
     }
 
     @Test
-    fun `test validation blank or whitespace name throws`() {
-        val exceptionEmpty = assertThrows<IllegalStateException> {
+    fun `test validation throws on invalid name or modifier`() {
+        val emptyEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("").entry(EnumEntrySpec.builder("a").build()).build()
         }
-        assertEquals("The enum name can not be empty or contain whitespaces", exceptionEmpty.message)
+        assertEquals("The enum name can not be empty or contain whitespaces", emptyEx.message)
 
-        val exceptionWhitespace = assertThrows<IllegalStateException> {
+        val whitespaceEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("Invalid Name").entry(EnumEntrySpec.builder("a").build()).build()
         }
-        assertEquals("The enum name can not be empty or contain whitespaces", exceptionWhitespace.message)
-    }
+        assertEquals("The enum name can not be empty or contain whitespaces", whitespaceEx.message)
 
-    @Test
-    fun `test validation duplicate entry name throws`() {
-        val exception = assertThrows<IllegalStateException> {
-            EnumSpec.builder("DupEntries")
-                .entry(EnumEntrySpec.builder("same").build())
-                .entry(EnumEntrySpec.builder("same").build())
-                .build()
-        }
-        assertTrue(exception.message!!.startsWith("Duplicate enum entry name(s) found"))
-    }
-
-    @Test
-    fun `test validation invalid modifier throws`() {
-        val exception = assertThrows<IllegalStateException> {
+        val modifierEx = assertThrows<IllegalStateException> {
             EnumSpec.builder("InvalidModifier")
                 .modifier(DartModifier.ABSTRACT)
                 .entry(EnumEntrySpec.builder("a").build())
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Enums only support PUBLIC or PRIVATE modifiers"))
+        assertTrue(modifierEx.message!!.startsWith("Enums only support PUBLIC or PRIVATE modifiers"))
     }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/enum/EnumSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/enum/EnumSpecTest.kt
@@ -125,6 +125,24 @@ class EnumSpecTest {
     }
 
     @Test
+    fun `test generic enum with string and bound overloads`() {
+        val enumSpec = EnumSpec.builder("Result")
+            .generic("T")
+            .generic("E", Comparable::class)
+            .entry(EnumEntrySpec.builder("success").build())
+            .build()
+
+        enumSpec.verifyDartOutput(
+            """
+            |enum Result<T, E extends Comparable> {
+            |
+            |  success
+            |}
+            """.trimMargin()
+        )
+    }
+
+    @Test
     fun `test enum with annotations and private modifier`() {
         val enumSpec = EnumSpec.builder("Status", DartModifier.PRIVATE)
             .annotation(AnnotationSpec.builder("deprecated").build())

--- a/src/test/kotlin/net/theevilreaper/dartpoet/meta/GenericMethodsTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/meta/GenericMethodsTest.kt
@@ -1,0 +1,76 @@
+package net.theevilreaper.dartpoet.meta
+
+import com.google.common.truth.Truth.assertThat
+import net.theevilreaper.dartpoet.clazz.ClassBuilder
+import net.theevilreaper.dartpoet.clazz.ClassType
+import net.theevilreaper.dartpoet.enum.EnumBuilder
+import net.theevilreaper.dartpoet.mixin.MixinBuilder
+import net.theevilreaper.dartpoet.type.ClassName
+import net.theevilreaper.dartpoet.type.TypeVariableName
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.lang.reflect.Type
+import java.util.stream.Stream
+
+@DisplayName("Test GenericMethods overloads across all type builders")
+class GenericMethodsTest {
+
+    companion object {
+        @JvmStatic
+        fun builders(): Stream<GenericMethods<*>> = Stream.of(
+            ClassBuilder("TestClass", ClassType.CLASS),
+            EnumBuilder("TestEnum"),
+            MixinBuilder("TestMixin")
+        )
+    }
+
+    private fun getGenerics(builder: GenericMethods<*>): List<String> = when (builder) {
+        is ClassBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
+        is EnumBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
+        is MixinBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
+        else -> error("Unknown builder: $builder")
+    }
+
+    @ParameterizedTest
+    @MethodSource("builders")
+    fun `test unconstrained string generic parameter`(builder: GenericMethods<*>) {
+        builder.generic("T")
+        assertThat(getGenerics(builder)).containsExactly("T")
+    }
+
+    @ParameterizedTest
+    @MethodSource("builders")
+    fun `test type conversion overloads`(builder: GenericMethods<*>) {
+        val reflectType: Type = String::class.java
+        builder.generic(ClassName("A"))
+        builder.generic(reflectType)
+        builder.generic(String::class)
+        builder.generic(CharSequence::class.java)
+
+        assertThat(getGenerics(builder)).containsExactly("A", "String", "String", "CharSequence").inOrder()
+    }
+
+    @ParameterizedTest
+    @MethodSource("builders")
+    fun `test bounded generic parameter overloads`(builder: GenericMethods<*>) {
+        builder.generic("T", ClassName("Comparable"))
+        builder.generic("K", String::class)
+        builder.generic("V", CharSequence::class.java)
+
+        assertThat(getGenerics(builder)).containsExactly(
+            "T extends Comparable",
+            "K extends String",
+            "V extends CharSequence"
+        ).inOrder()
+    }
+
+    @ParameterizedTest
+    @MethodSource("builders")
+    fun `test genericCast and genericCasts overloads`(builder: GenericMethods<*>) {
+        builder.genericCast(TypeVariableName("X"))
+        builder.genericCasts(TypeVariableName("Y"), TypeVariableName("Z"))
+
+        assertThat(getGenerics(builder)).containsExactly("X", "Y", "Z").inOrder()
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
@@ -103,26 +103,11 @@ class MixinSpecTest {
 
     @Test
     fun `test generic mixin`() {
-        val mixinSpec = MixinSpec.builder("Cache")
-            .generic("T")
-            .build()
-        mixinSpec.verifyDartOutput("mixin Cache<T> {}")
-    }
-
-    @Test
-    fun `test generic mixin with ClassName`() {
-        val mixinSpec = MixinSpec.builder("Cache")
-            .generic(ClassName("T"))
-            .build()
-        mixinSpec.verifyDartOutput("mixin Cache<T> {}")
-    }
-
-    @Test
-    fun `test generic mixin with bounded type`() {
         val mixinSpec = MixinSpec.builder("Repository")
             .generic("T", ClassName("Entity"))
+            .generic("R")
             .build()
-        assertEquals("mixin Repository<T extends Entity> {}", mixinSpec.toString())
+        mixinSpec.verifyDartOutput("mixin Repository<T extends Entity, R> {}")
     }
 
     @Test
@@ -241,50 +226,41 @@ class MixinSpecTest {
     }
 
     @Test
-    fun `test validation blank or whitespace name throws`() {
-        val exceptionEmpty = assertThrows<IllegalStateException> {
+    fun `test validation throws on invalid name or modifier`() {
+        val emptyEx = assertThrows<IllegalStateException> {
             MixinSpec.builder("").build()
         }
-        assertEquals("The mixin name can not be empty or contain whitespaces", exceptionEmpty.message)
+        assertEquals("The mixin name can not be empty or contain whitespaces", emptyEx.message)
 
-        val exceptionWhitespace = assertThrows<IllegalStateException> {
+        val whitespaceEx = assertThrows<IllegalStateException> {
             MixinSpec.builder("Invalid Name").build()
         }
-        assertEquals("The mixin name can not be empty or contain whitespaces", exceptionWhitespace.message)
-    }
+        assertEquals("The mixin name can not be empty or contain whitespaces", whitespaceEx.message)
 
-    @Test
-    fun `test validation invalid modifier throws`() {
-        val exception = assertThrows<IllegalStateException> {
+        val modifierEx = assertThrows<IllegalStateException> {
             MixinSpec.builder("InvalidModifier")
                 .modifier(DartModifier.ABSTRACT)
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("A mixin can only have the 'base' modifier"))
+        assertTrue(modifierEx.message!!.startsWith("A mixin can only have the 'base' modifier"))
     }
 
     @Test
-    fun `test validation duplicate on types throws`() {
-        val exception = assertThrows<IllegalStateException> {
+    fun `test validation throws on duplicate elements`() {
+        val dupOnEx = assertThrows<IllegalStateException> {
             MixinSpec.builder("DupOn")
                 .on(ClassName("Base"), ClassName("Base"))
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Duplicate 'on' type(s) found"))
-    }
+        assertTrue(dupOnEx.message!!.startsWith("Duplicate 'on' type(s) found"))
 
-    @Test
-    fun `test validation duplicate interfaces throws`() {
-        val exception = assertThrows<IllegalStateException> {
+        val dupInterfaceEx = assertThrows<IllegalStateException> {
             MixinSpec.builder("DupInterface")
                 .implements(ClassName("I1"), ClassName("I1"))
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Duplicate interface type(s) found"))
-    }
+        assertTrue(dupInterfaceEx.message!!.startsWith("Duplicate interface type(s) found"))
 
-    @Test
-    fun `test validation duplicate operators throws`() {
         val op1 = DartOperatorSpec.builder(BinaryOperator.PLUS)
             .returnType(ClassName("int"))
             .parameter(ParameterSpec.positional("other", ClassName("int")).build())
@@ -295,14 +271,13 @@ class MixinSpecTest {
             .parameter(ParameterSpec.positional("other", ClassName("int")).build())
             .addCode("return 2;")
             .build()
-
-        val exception = assertThrows<IllegalStateException> {
+        val dupOperatorEx = assertThrows<IllegalStateException> {
             MixinSpec.builder("DupOperator")
                 .operator(op1)
                 .operator(op2)
                 .build()
         }
-        assertTrue(exception.message!!.startsWith("Duplicate operator(s) found"))
+        assertTrue(dupOperatorEx.message!!.startsWith("Duplicate operator(s) found"))
     }
 
     @Test

--- a/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/mixin/MixinSpecTest.kt
@@ -104,6 +104,14 @@ class MixinSpecTest {
     @Test
     fun `test generic mixin`() {
         val mixinSpec = MixinSpec.builder("Cache")
+            .generic("T")
+            .build()
+        mixinSpec.verifyDartOutput("mixin Cache<T> {}")
+    }
+
+    @Test
+    fun `test generic mixin with ClassName`() {
+        val mixinSpec = MixinSpec.builder("Cache")
             .generic(ClassName("T"))
             .build()
         mixinSpec.verifyDartOutput("mixin Cache<T> {}")


### PR DESCRIPTION
## Proposed changes

This PR introduces the GenericMethods interface in the meta package to establish a uniform contract for declarations that support generic type parameters. ClassBuilder, EnumBuilder, and MixinBuilder now share the exact same set of generic configuration methods, including intuitive unconstrained declarations like generic("T") as well as bounded parameters across TypeName, KClass, and Java Class types. In addition, existing spec tests for classes, enums, and mixins have been consolidated and streamlined to eliminate redundant test cases while keeping overall verification reliable and clean.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)