### PR TITLE
feat(function): support GenericMethods interface

### DIFF
--- a/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
+++ b/src/main/kotlin/net/theevilreaper/dartpoet/function/FunctionBuilder.kt
@@ -3,6 +3,7 @@ package net.theevilreaper.dartpoet.function
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.annotation.AnnotationSpec
 import net.theevilreaper.dartpoet.code.CodeBlock
+import net.theevilreaper.dartpoet.meta.GenericMethods
 import net.theevilreaper.dartpoet.meta.SpecData
 import net.theevilreaper.dartpoet.meta.SpecMethods
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
@@ -25,7 +26,7 @@ import kotlin.reflect.KClass
 class FunctionBuilder internal constructor(
     val name: String,
     var returnType: TypeName = VOID
-) : SpecMethods<FunctionBuilder> {
+) : SpecMethods<FunctionBuilder>, GenericMethods<FunctionBuilder> {
     internal val specData: SpecData = SpecData()
     internal val parameters: MutableList<ParameterSpec> = mutableListOf()
     internal var async: Boolean = false
@@ -63,11 +64,38 @@ class FunctionBuilder internal constructor(
     }
 
     /**
+     * Adds a generic type parameter as a [TypeName].
+     * @param typeName the type name to add
+     * @return the given instance of an [FunctionBuilder]
+     */
+    override fun genericCast(typeName: TypeName) = apply {
+        this.genericCasts += typeName
+    }
+
+    /**
+     * Adds multiple generic type parameters as [TypeName] instances.
+     * @param typeNames the type names to add
+     * @return the given instance of an [FunctionBuilder]
+     */
+    override fun genericCasts(vararg typeNames: TypeName) = apply {
+        this.genericCasts += typeNames
+    }
+
+    /**
+     * Add an unconstrained generic type parameter with the given [name].
+     * @param name the name of the generic type variable (e.g. "T")
+     * @return the given instance of an [FunctionBuilder]
+     */
+    override fun generic(name: String) = apply {
+        this.genericCasts += TypeVariableName(name)
+    }
+
+    /**
      * Add a generic type to the function builder.
      * @param type the [ClassName] to add
      * @return the given instance of an [FunctionBuilder]
      */
-    fun generic(type: ClassName) = apply {
+    override fun generic(type: ClassName) = apply {
         this.genericCasts += type
     }
 
@@ -76,7 +104,7 @@ class FunctionBuilder internal constructor(
      * @param type the [Type] to add
      * @return the given instance of an [FunctionBuilder]
      */
-    fun generic(type: Type) = apply {
+    override fun generic(type: Type) = apply {
         generic(TypeName.get(type) as ClassName)
     }
 
@@ -85,7 +113,16 @@ class FunctionBuilder internal constructor(
      * @param type the [KClass] to add
      * @return the given instance of an [FunctionBuilder]
      */
-    fun generic(type: KClass<*>) = apply {
+    override fun generic(type: KClass<*>) = apply {
+        generic(type.asClassName())
+    }
+
+    /**
+     * Add a generic type to the function builder.
+     * @param type the [Class] to add
+     * @return the given instance of an [FunctionBuilder]
+     */
+    override fun generic(type: Class<*>) = apply {
         generic(type.asClassName())
     }
 
@@ -95,7 +132,7 @@ class FunctionBuilder internal constructor(
      * @param bound the bound of the type parameter, represented as a [TypeName]
      * @return the given instance of an [FunctionBuilder]
      */
-    fun generic(name: String, bound: TypeName) = apply {
+    override fun generic(name: String, bound: TypeName) = apply {
         this.genericCasts += TypeVariableName(name, bound)
     }
 
@@ -105,7 +142,7 @@ class FunctionBuilder internal constructor(
      * @param bound the bound of the type parameter, represented as a [ClassName]
      * @return the given instance of an [FunctionBuilder]
      */
-    fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
+    override fun generic(name: String, bound: ClassName) = generic(name, bound as TypeName)
 
     /**
      * Add a bounded generic type parameter to the function builder, e.g. `T extends Bar`.
@@ -113,7 +150,15 @@ class FunctionBuilder internal constructor(
      * @param bound the bound of the type parameter, represented as a [KClass]
      * @return the given instance of an [FunctionBuilder]
      */
-    fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
+    override fun generic(name: String, bound: KClass<*>) = generic(name, bound.asTypeName())
+
+    /**
+     * Add a bounded generic type parameter to the function builder, e.g. `T extends Bar`.
+     * @param name the name of the type parameter
+     * @param bound the bound of the type parameter, represented as a Java [Class]
+     * @return the given instance of an [FunctionBuilder]
+     */
+    override fun generic(name: String, bound: Class<*>) = generic(name, bound.asClassName())
 
     fun addCode(format: String, vararg args: Any?) = apply {
         body.add(format, *args)

--- a/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/function/FunctionSpecTest.kt
@@ -174,4 +174,22 @@ class FunctionSpecTest {
         assertTrue { specAsBuilder.body.isNotEmpty() }
         assertEquals(functionSpec.genericCasts, specAsBuilder.genericCasts)
     }
+
+    @Test
+    fun `test generic function with string overload`() {
+        val functionSpec = FunctionSpec.builder("identity")
+            .generic("T")
+            .returns(ClassName("T"))
+            .parameter(ParameterSpec.positional("value", ClassName("T")).build())
+            .addCode("return value;")
+            .build()
+        assertEquals(
+            """
+            |T identity<T>(T value) {
+            |  return value;
+            |}
+            """.trimMargin(),
+            functionSpec.toString()
+        )
+    }
 }

--- a/src/test/kotlin/net/theevilreaper/dartpoet/meta/GenericMethodsTest.kt
+++ b/src/test/kotlin/net/theevilreaper/dartpoet/meta/GenericMethodsTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import net.theevilreaper.dartpoet.clazz.ClassBuilder
 import net.theevilreaper.dartpoet.clazz.ClassType
 import net.theevilreaper.dartpoet.enum.EnumBuilder
+import net.theevilreaper.dartpoet.function.FunctionBuilder
 import net.theevilreaper.dartpoet.mixin.MixinBuilder
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.dartpoet.type.TypeVariableName
@@ -21,7 +22,8 @@ class GenericMethodsTest {
         fun builders(): Stream<GenericMethods<*>> = Stream.of(
             ClassBuilder("TestClass", ClassType.CLASS),
             EnumBuilder("TestEnum"),
-            MixinBuilder("TestMixin")
+            MixinBuilder("TestMixin"),
+            FunctionBuilder("testFunc")
         )
     }
 
@@ -29,6 +31,7 @@ class GenericMethodsTest {
         is ClassBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
         is EnumBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
         is MixinBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
+        is FunctionBuilder -> builder.genericCasts.map { TypeVariableName.renderDeclaration(it) }
         else -> error("Unknown builder: $builder")
     }
 


### PR DESCRIPTION
## Proposed changes

This PR connects FunctionBuilder to the GenericMethods interface so that function declarations share the exact same generic configuration contract as `classes`, `enums` and `mixins`. Functions now support intuitive unconstrained generic parameters like `generic("T")`, full Java class interop and the genericCast methods. Existing generic tests have also been extended to verify all four builder types in a unified parameterized test suite.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)